### PR TITLE
Improved error output from service

### DIFF
--- a/BookingsAPI/Bookings.API/Mappings/ParticipantRequestToNewParticipantMapper.cs
+++ b/BookingsAPI/Bookings.API/Mappings/ParticipantRequestToNewParticipantMapper.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Linq;
 using Bookings.Api.Contract.Requests;
+using Bookings.Common;
 using Bookings.DAL.Commands;
 using Bookings.Domain;
 using Bookings.Domain.RefData;
@@ -14,8 +16,11 @@ namespace Bookings.API.Mappings
     {
         public NewParticipant MapRequestToNewParticipant(ParticipantRequest requestParticipant, CaseType caseType)
         {
-            var caseRole = caseType.CaseRoles.Single(x => x.Name == requestParticipant.CaseRoleName);
-            var hearingRole = caseRole.HearingRoles.Single(x => x.Name == requestParticipant.HearingRoleName);
+            var caseRole = caseType.CaseRoles.FirstOrDefault(x => x.Name == requestParticipant.CaseRoleName);
+            if (caseRole == null) throw new BadRequestException($"Invalid case role [{requestParticipant.CaseRoleName}]");
+            
+            var hearingRole = caseRole.HearingRoles.FirstOrDefault(x => x.Name == requestParticipant.HearingRoleName);
+            if (hearingRole == null) throw new BadRequestException($"Invalid hearing role [{requestParticipant.HearingRoleName}]");
 
             var person = new Person(requestParticipant.Title, requestParticipant.FirstName, requestParticipant.LastName,
                 requestParticipant.Username)

--- a/BookingsAPI/Bookings.UnitTests/Bookings.UnitTests.csproj
+++ b/BookingsAPI/Bookings.UnitTests/Bookings.UnitTests.csproj
@@ -22,7 +22,4 @@
     <ProjectReference Include="..\Bookings.Domain\Bookings.Domain.csproj" />
     <ProjectReference Include="..\Testing.Common\Testing.Common.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Controllers\HealthChecksController" />
-  </ItemGroup>
 </Project>

--- a/BookingsAPI/Bookings.UnitTests/Mappings/ParticipantRequestToNewParticipantMapperTest.cs
+++ b/BookingsAPI/Bookings.UnitTests/Mappings/ParticipantRequestToNewParticipantMapperTest.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bookings.Api.Contract.Requests;
+using FluentAssertions;
+using Bookings.Common;
+using Bookings.Api.Contract.Responses;
+using Bookings.API.Mappings;
+using Bookings.API.Utilities;
+using Bookings.Domain;
+using Bookings.Domain.RefData;
+using Bookings.UnitTests.Utilities;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+
+namespace Bookings.UnitTests.Mappings
+{
+    public class ParticipantRequestToNewParticipantMapperTest  : TestBase
+    {
+        private CaseType _caseType;
+
+        [SetUp]
+        public void Setup()
+    {
+            _caseType = new CaseType(1, "Money claims")
+            {
+                CaseRoles = new List<CaseRole>
+                {
+                    new CaseRole(0, "Claimant")
+                    {
+                        HearingRoles = new List<HearingRole>
+                        {
+                            new HearingRole(1, "Claimant LIP"),
+                            new HearingRole(2, "Solicitor")
+                        }
+                    },
+                    new CaseRole(0, "Respondent")
+                    {
+                        HearingRoles = new List<HearingRole>
+                        {
+                            new HearingRole(1, "Respondent LIP"),
+                            new HearingRole(2, "Solicitor")
+                        }
+                    }
+                }
+            };
+        }
+        
+        [Test]
+        public void should_raise_bad_request_exception_on_invalid_case_role()
+        {
+            var request = new ParticipantRequest
+            {
+                CaseRoleName = "Missing case role",
+                HearingRoleName = "Solicitor"
+            };
+
+            When(() => new ParticipantRequestToNewParticipantMapper().MapRequestToNewParticipant(request, _caseType))
+                .Should().Throw<BadRequestException>().WithMessage("Invalid case role [Missing case role]");
+        }
+        
+        [Test]
+        public void should_raise_bad_request_exception_on_invalid_hearing_role()
+        {
+            var request = new ParticipantRequest
+            {
+                CaseRoleName = "Claimant",
+                HearingRoleName = "Missing hearing role"
+            };
+
+            When(() => new ParticipantRequestToNewParticipantMapper().MapRequestToNewParticipant(request, _caseType))
+                .Should().Throw<BadRequestException>().WithMessage("Invalid hearing role [Missing hearing role]");
+        }
+    }
+}

--- a/BookingsAPI/Bookings.UnitTests/Utilities/PaginationBuilderTest.cs
+++ b/BookingsAPI/Bookings.UnitTests/Utilities/PaginationBuilderTest.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 
 namespace Bookings.UnitTests.Utilities
 {
-    public class PaginationBuilderTest
+    public class PaginationBuilderTest : TestBase
     {
         private const string SomeResourceUrl = "/api/hearings/participants/checklists";
 
@@ -137,12 +137,6 @@ namespace Bookings.UnitTests.Utilities
         private PaginationBuilder<StubPagedResponse, string> GetBuilder()
         {
             return new PaginationBuilder<StubPagedResponse, string>(items => new StubPagedResponse {Items = items});
-        }
-
-        /// <summary>Help wrapper to build catch clauses</summary>
-        private Action When(Action action)
-        {
-            return action;
         }
 
         private IQueryable<string> GetQueryableItems(params string[] items)

--- a/BookingsAPI/Bookings.UnitTests/Utilities/TestBase.cs
+++ b/BookingsAPI/Bookings.UnitTests/Utilities/TestBase.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Bookings.UnitTests.Utilities
+{
+    /// <summary>
+    /// Base class providing a number of useful helper methods
+    /// </summary>
+    public abstract class TestBase
+    {
+        /// <summary>Help wrapper to build catch clauses</summary>
+        protected static Action When(Action action)
+        {
+            return action;
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
Addition to VIH-2701

### Change description ###
Changed `.Single()` usage to `.FirstOrDefault()` and captured null output in order to give better error responses from service.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
