### PR TITLE
rename CaseRoleGroup enum values to correct values

### DIFF
--- a/BookingsAPI/Bookings.DAL/Migrations/20190315100721_AddOtherInformationToHearing.cs
+++ b/BookingsAPI/Bookings.DAL/Migrations/20190315100721_AddOtherInformationToHearing.cs
@@ -32,7 +32,7 @@ namespace Bookings.DAL.Migrations
                 columns: new[] { "Id", "Name", "Group", "CaseTypeId" },
                 values: new object[,]
                 {
-                    {5, "Judge", (int) CaseRoleGroup.PartyGroup3, 1},
+                    {5, "Judge", (int) CaseRoleGroup.Judge, 1},
                 });
         }
 

--- a/BookingsAPI/Bookings.DAL/SeedData/SeedCaseTypesData.cs
+++ b/BookingsAPI/Bookings.DAL/SeedData/SeedCaseTypesData.cs
@@ -64,10 +64,10 @@ namespace Bookings.DAL.SeedData
                 columns: new[] {"Id", "Name", "Group", "CaseTypeId"},
                 values: new object[,]
                 {
-                    {1, "Claimant", (int) CaseRoleGroup.PartyGroup1, 1},
-                    {2, "Defendant", (int) CaseRoleGroup.PartyGroup2, 1},
-                    {3, "Applicant", (int) CaseRoleGroup.PartyGroup1, 2},
-                    {4, "Respondent", (int) CaseRoleGroup.PartyGroup2, 2}
+                    {1, "Claimant", (int) CaseRoleGroup.Claimant, 1},
+                    {2, "Defendant", (int) CaseRoleGroup.Defendant, 1},
+                    {3, "Applicant", (int) CaseRoleGroup.Applicant, 2},
+                    {4, "Respondent", (int) CaseRoleGroup.Respondent, 2}
                 });
         }
 

--- a/BookingsAPI/Bookings.Domain/Enumerations/CaseRoleGroup.cs
+++ b/BookingsAPI/Bookings.Domain/Enumerations/CaseRoleGroup.cs
@@ -2,9 +2,10 @@ namespace Bookings.Domain.Enumerations
 {
     public enum CaseRoleGroup
     {
-        PartyGroup0 = 0,
-        PartyGroup1 = 1,
-        PartyGroup2 = 2,
-        PartyGroup3 = 3,
+        Judge = 0,
+        Claimant = 1,
+        Defendant = 2,
+        Applicant = 3,
+        Respondent = 4
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-4510](https://tools.hmcts.net/jira/browse/VIH-4510)

### Change description ###

The CaseRoleGroups enum values have been renamed to be meaningful. At the moment when a booking is queued, the data for party groups are not representative of the case type and role

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```