### PR TITLE
fix cursor of request for suitability answers

### DIFF
--- a/BookingsAPI/Bookings.DAL/Queries/GetParticipantWithSuitabilityAnswersQuery.cs
+++ b/BookingsAPI/Bookings.DAL/Queries/GetParticipantWithSuitabilityAnswersQuery.cs
@@ -52,9 +52,8 @@ namespace Bookings.DAL.Queries
             if (!string.IsNullOrEmpty(query.Cursor))
             {
                 TryParseCursor(query.Cursor, out var updatedDateTime, out var id);
-                participants = participants.Where(x => (x.SuitabilityAnswerUpdatedAt < updatedDateTime
-                                               || x.SuitabilityAnswerUpdatedAt == updatedDateTime)
-                                               && (x.Id.ToString() == id || string.Compare(x.Id.ToString(), id, true) > 0));
+                participants = participants.Where(x => x.SuitabilityAnswerUpdatedAt <= updatedDateTime
+                                               &&  string.Compare(x.Id.ToString(), id, true) > 0);
             }
 
             // Add one to the limit to know whether or not we have a next page

--- a/BookingsAPI/Bookings.DAL/Queries/GetParticipantWithSuitabilityAnswersQuery.cs
+++ b/BookingsAPI/Bookings.DAL/Queries/GetParticipantWithSuitabilityAnswersQuery.cs
@@ -52,9 +52,9 @@ namespace Bookings.DAL.Queries
             if (!string.IsNullOrEmpty(query.Cursor))
             {
                 TryParseCursor(query.Cursor, out var updatedDateTime, out var id);
-                participants = participants.Where(x => x.SuitabilityAnswerUpdatedAt < updatedDateTime
-                                               || x.SuitabilityAnswerUpdatedAt == updatedDateTime
-                                               && string.Compare(x.Id.ToString(), id, StringComparison.Ordinal) > 0);
+                participants = participants.Where(x => (x.SuitabilityAnswerUpdatedAt < updatedDateTime
+                                               || x.SuitabilityAnswerUpdatedAt == updatedDateTime)
+                                               && (x.Id.ToString() == id || string.Compare(x.Id.ToString(), id, true) > 0));
             }
 
             // Add one to the limit to know whether or not we have a next page

--- a/BookingsAPI/Bookings.IntegrationTests/Steps/SuitabilityAnswersSteps.cs
+++ b/BookingsAPI/Bookings.IntegrationTests/Steps/SuitabilityAnswersSteps.cs
@@ -32,6 +32,7 @@ namespace Bookings.IntegrationTests.Steps
             var json = await ApiTestContext.ResponseMessage.Content.ReadAsStringAsync();
             var model = ApiRequestHelper.DeserialiseSnakeCaseJsonToResponse<SuitabilityAnswersResponse>(json);
             model.Should().NotBeNull();
+            model.PrevPageUrl.Should().NotBe(model.NextPageUrl);
             model.ParticipantSuitabilityAnswerResponse.Should().NotBeNull();
             model.ParticipantSuitabilityAnswerResponse.Count.Should().BeGreaterThan(0);
             var participantAnswer = model.ParticipantSuitabilityAnswerResponse[0];


### PR DESCRIPTION

### Change description ###
Fix cursor problem to get suitability answer list

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
