### PR TITLE
Added more test data prefixes

### DIFF
--- a/BookingsAPI/Bookings.AcceptanceTests/Models/AddParticipantRequest.cs
+++ b/BookingsAPI/Bookings.AcceptanceTests/Models/AddParticipantRequest.cs
@@ -9,12 +9,12 @@ namespace Bookings.AcceptanceTests.Models
         public static AddParticipantsToHearingRequest BuildRequest()
         {
             var participants = Builder<ParticipantRequest>.CreateListOfSize(1).All()
-                .With(x => x.ContactEmail = Faker.Internet.Email())
-                .With(x => x.Username = Faker.Internet.Email())
+                .With(x => x.ContactEmail = $"Automation_{Faker.Internet.Email()}")
+                .With(x => x.Username = $"Automation_{Faker.Internet.Email()}")
                 .Build().ToList();
             participants[0].CaseRoleName = "Claimant";
             participants[0].HearingRoleName = "Claimant LIP";
-            participants[0].FirstName = "Added Participant";
+            participants[0].FirstName = "Automation_Added Participant";
             var request = new AddParticipantsToHearingRequest{Participants = participants};
             return request;
         }

--- a/BookingsAPI/Bookings.AcceptanceTests/Steps/HearingsSteps.cs
+++ b/BookingsAPI/Bookings.AcceptanceTests/Steps/HearingsSteps.cs
@@ -152,7 +152,7 @@ namespace Bookings.AcceptanceTests.Steps
         }
 
         [Given(@"I have a valid book a new hearing for a case type (.*)")]
-        public void GivenIHaveAValidBookANewHearingForAcaseType(string caseType)
+        public void GivenIHaveAValidBookANewHearingForACaseType(string caseType)
         {
             var request = new CreateHearingRequestBuilder().WithContext(_context).Build();
             request.ScheduledDateTime = DateTime.Now.AddDays(2);

--- a/BookingsAPI/Bookings.AcceptanceTests/Steps/ParticipantsSteps.cs
+++ b/BookingsAPI/Bookings.AcceptanceTests/Steps/ParticipantsSteps.cs
@@ -71,7 +71,7 @@ namespace Bookings.AcceptanceTests.Steps
             var model = ApiRequestHelper.DeserialiseSnakeCaseJsonToResponse<List<ParticipantResponse>>(_context.Json);
             if (state.Equals("added"))
             {
-                var exists = model.Exists(x => x.FirstName == "Added Participant");
+                var exists = model.Exists(x => x.FirstName == "Automation_Added Participant");
                 exists.Should().BeTrue();
             }
             if (!state.Equals("removed")) return;

--- a/BookingsAPI/Testing.Common/Builders/Api/Request/ParticipantRequestBuilder.cs
+++ b/BookingsAPI/Testing.Common/Builders/Api/Request/ParticipantRequestBuilder.cs
@@ -14,10 +14,10 @@ namespace Testing.Common.Builders.Api.Request
                 .With(x => x.CaseRoleName = caseRole)
                 .With(x => x.HearingRoleName = hearingRole)
                 .With(x => x.Title = Name.Prefix())
-                .With(x => x.FirstName = Name.First())
-                .With(x => x.LastName = Name.Last())
-                .With(x => x.Username = Internet.Email())
-                .With(x => x.ContactEmail = Internet.Email())
+                .With(x => x.FirstName = $"Automation_{Name.First()}")
+                .With(x => x.LastName = $"Automation_{Name.Last()}")
+                .With(x => x.Username = $"Automation_{Internet.Email()}")
+                .With(x => x.ContactEmail = $"Automation_{Internet.Email()}")
                 .With(x => x.TelephoneNumber = Phone.Number())
                 .Build();
         }

--- a/BookingsAPI/Testing.Common/Builders/Domain/PersonBuilder.cs
+++ b/BookingsAPI/Testing.Common/Builders/Domain/PersonBuilder.cs
@@ -26,7 +26,7 @@ namespace Testing.Common.Builders.Domain
                 
             }
             _person = new Builder(_settings).CreateNew<Person>().WithFactory(() =>
-                    new Person(Name.Prefix(), Name.First(), Name.Last(), Internet.Email())).With(x => x.ContactEmail = Internet.Email())
+                    new Person(Name.Prefix(), $"Automation_{Name.First()}", $"Automation_{Name.Last()}", $"Automation_{Internet.Email()}")).With(x => x.ContactEmail = $"Automation_{Internet.Email()}")
                 .With(x => x.UpdatedDate, DateTime.MinValue)
                 .Build();
         }
@@ -35,7 +35,7 @@ namespace Testing.Common.Builders.Domain
         {
             var settings = new BuilderSettings();
             _person = new Builder(settings).CreateNew<Person>().WithFactory(() =>
-                    new Person(Name.Prefix(), Name.First(), Name.Last(), userId)).With(x => x.ContactEmail = Internet.Email())
+                    new Person(Name.Prefix(), $"Automation_{Name.First()}", $"Automation_{Name.Last()}", userId)).With(x => x.ContactEmail = $"Automation_{Internet.Email()}")
                 .Build();
         }
 
@@ -72,7 +72,7 @@ namespace Testing.Common.Builders.Domain
             if (_participants == null || _nextParticipantIndex >= numParticipantsToCreate)
             {
                 _participants = Builder<Person>.CreateListOfSize(numParticipantsToCreate).All().WithFactory(() =>
-                        new Person(Name.Prefix(), Name.First(), Name.Last(), Internet.Email())).With(x => x.ContactEmail = Internet.Email())
+                        new Person(Name.Prefix(), $"Automation_{Name.First()}", $"Automation_{Name.Last()}", $"Automation_{Internet.Email()}")).With(x => x.ContactEmail = $"Automation_{Internet.Email()}")
                     .Build().ToList();
                 _nextParticipantIndex = 0;
             }


### PR DESCRIPTION
- [X] commit messages are meaningful and follow good commit message guidelines
- [X] tests have been updated / new tests has been added (if needed)

### Change description ###
Added more prefixes so all created users are not prefixed with "Automation_" to make them easily identifiable in AAD, and thus easy to cleanup at a later date.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
