### PR TITLE
VIH-7401 fix Remove Hearing with linked participants 

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Commands/RemoveHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/RemoveHearingCommand.cs
@@ -48,7 +48,7 @@ namespace BookingsApi.DAL.Commands
             _context.RemoveRange(hearingsIncCloned.SelectMany(h => h.GetEndpoints()));
             _context.RemoveRange(hearingsIncCloned.SelectMany(h => h.GetCases()));
 
-            RemoveLinkedParticipants(hearingsIncCloned);
+            await RemoveLinkedParticipants(hearingsIncCloned);
 
             var persons = hearingsIncCloned.SelectMany(h => h.Participants.Select(x => x.Person)).ToList();
             var organisations = persons.Where(p => p.Organisation != null).Select(x => x.Organisation).ToList();
@@ -60,7 +60,7 @@ namespace BookingsApi.DAL.Commands
             await _context.SaveChangesAsync();
         }
 
-        private void RemoveLinkedParticipants(List<VideoHearing> hearingsIncCloned)
+        private async Task RemoveLinkedParticipants(List<VideoHearing> hearingsIncCloned)
         {
             var participants = hearingsIncCloned.SelectMany(h => h.Participants);
             foreach (var participant in participants)
@@ -72,6 +72,7 @@ namespace BookingsApi.DAL.Commands
                     _context.Remove(linkedParticipant);
                 }
             }
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/RemoveHearingCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/RemoveHearingCommandTests.cs
@@ -4,6 +4,7 @@ using BookingsApi.DAL;
 using BookingsApi.DAL.Commands;
 using BookingsApi.DAL.Exceptions;
 using BookingsApi.DAL.Queries;
+using BookingsApi.Domain.Enumerations;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -40,8 +41,23 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             _newHearingId = seededHearing.Id;
 
             await _commandHandler.Handle(new RemoveHearingCommand(seededHearing.Id));
+                
+            var returnedVideoHearing =
+                await _getHearingByIdQueryHandler.Handle(new GetHearingByIdQuery(seededHearing.Id));
+            returnedVideoHearing.Should().BeNull();
 
+            _newHearingId = Guid.Empty;
+        }
+        
+        [Test]
+        public async Task Should_remove_hearing_containing_interpreter()
+        {
+            var seededHearing = await Hooks.SeedVideoHearing(null, false,BookingStatus.Booked,0,false,true);
+            TestContext.WriteLine($"New seeded video hearing id: {seededHearing.Id}");
+            _newHearingId = seededHearing.Id;
 
+            await _commandHandler.Handle(new RemoveHearingCommand(seededHearing.Id));
+                
             var returnedVideoHearing =
                 await _getHearingByIdQueryHandler.Handle(new GetHearingByIdQuery(seededHearing.Id));
             returnedVideoHearing.Should().BeNull();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7401

### Change description ###
A test has been added for RemoveHearingCommand when the hearing contains linked participants
The RemoveHearingCommand now removes all linked participants entries, saves the context and then continues processing the removal of the hearing and participants 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
