### PR TITLE
VIH-8081 remove interpreter causes error

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
@@ -74,7 +74,7 @@ namespace BookingsApi.DAL.Commands
                     throw new ParticipantNotFoundException(newExistingParticipantDetails.ParticipantId);
                 }
 
-                await _hearingService.RemoveParticipantLinks(participants, existingParticipant);
+                existingParticipant.LinkedParticipants.Clear();
 
                 existingParticipant.UpdateParticipantDetails(newExistingParticipantDetails.Title, newExistingParticipantDetails.DisplayName,
                     newExistingParticipantDetails.TelephoneNumber, newExistingParticipantDetails.OrganisationName);

--- a/BookingsApi/BookingsApi.DAL/Queries/GetPersonBySearchTermQuery.cs
+++ b/BookingsApi/BookingsApi.DAL/Queries/GetPersonBySearchTermQuery.cs
@@ -20,19 +20,19 @@ namespace BookingsApi.DAL.Queries
     public class GetPersonBySearchTermQueryHandler : IQueryHandler<GetPersonBySearchTermQuery, List<Person>>
     {
         private readonly BookingsDbContext _context;
+        public static readonly List<string> excludedRoles = new List<string>() { "Judge", "JudicialOfficeHolder", "StaffMember" };
 
-        public GetPersonBySearchTermQueryHandler(BookingsDbContext context)
+    public GetPersonBySearchTermQueryHandler(BookingsDbContext context)
         {
             _context = context;
         }
 
         public async Task<List<Person>> Handle(GetPersonBySearchTermQuery query)
         {
-            var excludeRoles = new List<string>() { "Judge", "JudicialOfficeHolder", "StaffMember" };
 
             var results = await (from person in _context.Persons
              join participant in _context.Participants on person.Id equals participant.PersonId
-             where !excludeRoles.Contains(participant.Discriminator) 
+             where !excludedRoles.Contains(participant.Discriminator) 
              && person.ContactEmail.ToLower().Contains(query.Term.ToLower())
              select person).Distinct().Include(x => x.Organisation).ToListAsync();
 

--- a/BookingsApi/BookingsApi.DAL/Queries/GetPersonBySearchTermQuery.cs
+++ b/BookingsApi/BookingsApi.DAL/Queries/GetPersonBySearchTermQuery.cs
@@ -22,7 +22,7 @@ namespace BookingsApi.DAL.Queries
         private readonly BookingsDbContext _context;
         public static readonly List<string> excludedRoles = new List<string>() { "Judge", "JudicialOfficeHolder", "StaffMember" };
 
-    public GetPersonBySearchTermQueryHandler(BookingsDbContext context)
+        public GetPersonBySearchTermQueryHandler(BookingsDbContext context)
         {
             _context = context;
         }

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetPersonBySearchTermQueryHandlerDatabaseTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetPersonBySearchTermQueryHandlerDatabaseTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using BookingsApi.DAL;
@@ -22,7 +23,7 @@ namespace BookingsApi.IntegrationTests.Database.Queries
         public async Task Should_find_contact_by_email_case_insensitive()
         {
             var seededHearing = await Hooks.SeedVideoHearing();
-            var person = seededHearing.GetPersons().First();
+            var person = seededHearing.GetPersons().First(x => seededHearing.Participants.Any(p => p.PersonId == x.Id && !GetPersonBySearchTermQueryHandler.excludedRoles.Contains(p.Discriminator)));
             var contactEmail = person.ContactEmail;
             
             // Build a search term based on lower and upper case of the expected email


### PR DESCRIPTION
### JIRA link (if applicable) ###
VIH-8081


### Change description ###
Clearing linked participant list rather than using hearing service which breaks when a linked participant has already been moved. EDIT: This now includes a fix for an intermittently failing integration test.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
