### PR TITLE
VIH-8792 Change CloneHearing endpoint to return list of new hearing ids

### DIFF
--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -348,14 +348,14 @@ namespace BookingsApi.Client
         /// <param name="hearingId">Original hearing to clone</param>
         /// <param name="request">List of dates to create a new hearing on</param>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request);
+        System.Threading.Tasks.Task<CloneHearingResponse> CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request);
     
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>Create a new hearing with the details of a given hearing on given dates</summary>
         /// <param name="hearingId">Original hearing to clone</param>
         /// <param name="request">List of dates to create a new hearing on</param>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<CloneHearingResponse> CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request, System.Threading.CancellationToken cancellationToken);
     
         /// <summary>Get a paged list of booked hearings</summary>
         /// <param name="types">The hearing case types.</param>
@@ -2990,7 +2990,7 @@ namespace BookingsApi.Client
         /// <param name="hearingId">Original hearing to clone</param>
         /// <param name="request">List of dates to create a new hearing on</param>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        public System.Threading.Tasks.Task CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request)
+        public System.Threading.Tasks.Task<CloneHearingResponse> CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request)
         {
             return CloneHearingAsync(hearingId, request, System.Threading.CancellationToken.None);
         }
@@ -3000,7 +3000,7 @@ namespace BookingsApi.Client
         /// <param name="hearingId">Original hearing to clone</param>
         /// <param name="request">List of dates to create a new hearing on</param>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        public async System.Threading.Tasks.Task CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request, System.Threading.CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<CloneHearingResponse> CloneHearingAsync(System.Guid hearingId, CloneHearingRequest request, System.Threading.CancellationToken cancellationToken)
         {
             if (hearingId == null)
                 throw new System.ArgumentNullException("hearingId");
@@ -3022,6 +3022,7 @@ namespace BookingsApi.Client
                     content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
     
                     PrepareRequest(client_, request_, urlBuilder_);
     
@@ -3044,9 +3045,14 @@ namespace BookingsApi.Client
                         ProcessResponse(client_, response_);
     
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 204)
+                        if (status_ == 200)
                         {
-                            return;
+                            var objectResponse_ = await ReadObjectResponseAsync<CloneHearingResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
                         }
                         else
                         if (status_ == 400)

--- a/BookingsApi/BookingsApi.Contract/Responses/CloneHearingResponse.cs
+++ b/BookingsApi/BookingsApi.Contract/Responses/CloneHearingResponse.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace BookingsApi.Contract.Responses
+{
+    public class CloneHearingResponse
+    {
+        public List<Guid> NewHearingIds { get; set; }
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Features/CloneHearing.feature
+++ b/BookingsApi/BookingsApi.IntegrationTests/Features/CloneHearing.feature
@@ -20,12 +20,12 @@ Scenario: Successfully clone a hearing with valid dates
 	Given I have a hearing with endpoints
 	And I have a request to clone a hearing with valid dates
 	When I send the request to the endpoint
-	Then the response should have the status NoContent and success status True
+	Then the response should have the status OK and success status True
 	And the database should have cloned hearings
 
 Scenario: Successfully clone a hearing with valid dates and with Linked Participants
 	Given I have a hearing with linked participants
 	And I have a request to clone a hearing with valid dates
 	When I send the request to the endpoint
-	Then the response should have the status NoContent and success status True
+	Then the response should have the status OK and success status True
 	And the database should have cloned hearings

--- a/BookingsApi/BookingsApi/Controllers/HearingsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingsController.cs
@@ -301,7 +301,7 @@ namespace BookingsApi.Controllers
         /// <returns></returns>
         [HttpPost("{hearingId}/clone")]
         [OpenApiOperation("CloneHearing")]
-        [ProducesResponseType((int) HttpStatusCode.NoContent)]
+        [ProducesResponseType(typeof(CloneHearingResponse), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int) HttpStatusCode.BadRequest)]
         public async Task<IActionResult> CloneHearing([FromRoute] Guid hearingId,
             [FromBody] CloneHearingRequest request)
@@ -339,8 +339,13 @@ namespace BookingsApi.Controllers
 
             var existingCase = videoHearing.GetCases().First();
             await _hearingService.UpdateHearingCaseName(hearingId, $"{existingCase.Name} Day {1} of {totalDays}");
+
+            var response = new CloneHearingResponse
+            {
+                NewHearingIds = commands.Select(c => c.NewHearingId).ToList()
+            };
             
-            return NoContent();
+            return Ok(response);
         }
 
         /// <summary>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8792

### Change description ###
Changes the CloneHearing endpoint to return a list of the new hearing ids created as a result of the clone. These ids will be used by Admin Web to confirm a multi-day booking as part of VIH-8792.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
