### PR TITLE
VIH-9109 Fix issue parsing JudiciaryPerson Id

### DIFF
--- a/BookingsApi/BookingsApi.Contract/Requests/JudiciaryPersonRequest.cs
+++ b/BookingsApi/BookingsApi.Contract/Requests/JudiciaryPersonRequest.cs
@@ -4,7 +4,7 @@ namespace BookingsApi.Contract.Requests
 {
     public class JudiciaryPersonRequest
     {
-        public Guid Id { get; set; }
+        public string Id { get; set; }
         public string PersonalCode { get; set; }
         public string Title { get; set; }
         public string KnownAs { get; set; }

--- a/BookingsApi/BookingsApi.DAL/Commands/AddJudiciaryPersonByExternalRefIdCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/AddJudiciaryPersonByExternalRefIdCommand.cs
@@ -9,7 +9,7 @@ namespace BookingsApi.DAL.Commands
 {
     public class AddJudiciaryPersonByExternalRefIdCommand : JudiciaryPersonCommandBase
     {
-        public AddJudiciaryPersonByExternalRefIdCommand(Guid externalRefId, string personalCode, string title,
+        public AddJudiciaryPersonByExternalRefIdCommand(string externalRefId, string personalCode, string title,
             string knownAs, string surname, string fullname, string postNominals, string email, bool hasLeft, bool leaver, string leftOn) :
             base(externalRefId, personalCode, title, knownAs, surname, fullname, postNominals, email, hasLeft, leaver, leftOn)
         {

--- a/BookingsApi/BookingsApi.DAL/Commands/AddJudiciaryPersonCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/AddJudiciaryPersonCommand.cs
@@ -7,7 +7,7 @@ namespace BookingsApi.DAL.Commands
 {
     public class AddJudiciaryPersonCommand : JudiciaryPersonCommandBase
     {
-        public AddJudiciaryPersonCommand(Guid externalRefId, string personalCode, string title, 
+        public AddJudiciaryPersonCommand(string externalRefId, string personalCode, string title, 
             string knownAs, string surname, string fullname, string postNominals, string email, bool hasLeft, bool leaver, string leftOn) : 
             base(externalRefId, personalCode, title, knownAs, surname, fullname, postNominals, email, hasLeft, leaver, leftOn)
         {

--- a/BookingsApi/BookingsApi.DAL/Commands/JudiciaryLeaverCommandBase.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/JudiciaryLeaverCommandBase.cs
@@ -5,13 +5,13 @@ namespace BookingsApi.DAL.Commands
 {
     public abstract class JudiciaryLeaverCommandBase : ICommand
     {
-        protected JudiciaryLeaverCommandBase(Guid externalRefId, bool leaver)
+        protected JudiciaryLeaverCommandBase(string externalRefId, bool leaver)
         {
             ExternalRefId = externalRefId;
             HasLeft = leaver;
         }
         
-        public Guid ExternalRefId { get; }
+        public string ExternalRefId { get; }
         public bool HasLeft { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.DAL/Commands/JudiciaryPersonCommandBase.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/JudiciaryPersonCommandBase.cs
@@ -5,7 +5,7 @@ namespace BookingsApi.DAL.Commands
 {
     public abstract class JudiciaryPersonCommandBase : ICommand
     {
-        protected JudiciaryPersonCommandBase(Guid externalRefId, string personalCode, string title,
+        protected JudiciaryPersonCommandBase(string externalRefId, string personalCode, string title,
             string knownAs, string surname, string fullname, string postNominals, string email, bool hasLeft,
             bool leaver, string leftOn)
         {
@@ -22,7 +22,7 @@ namespace BookingsApi.DAL.Commands
             LeftOn = leftOn;
         }
 
-        public Guid ExternalRefId { get; }
+        public string ExternalRefId { get; }
         public string PersonalCode { get; }
         public string Title { get; }
         public string KnownAs { get; }

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateJudiciaryLeaverByExternalRefIdCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateJudiciaryLeaverByExternalRefIdCommand.cs
@@ -8,7 +8,7 @@ namespace BookingsApi.DAL.Commands
 {
     public class UpdateJudiciaryLeaverByExternalRefIdCommand : JudiciaryLeaverCommandBase
     {
-        public UpdateJudiciaryLeaverByExternalRefIdCommand(Guid externalRefId, bool leaver) :
+        public UpdateJudiciaryLeaverByExternalRefIdCommand(string externalRefId, bool leaver) :
             base(externalRefId, leaver)
         {
         }

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateJudiciaryPersonByExternalRefIdCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateJudiciaryPersonByExternalRefIdCommand.cs
@@ -8,7 +8,7 @@ namespace BookingsApi.DAL.Commands
 {
     public class UpdateJudiciaryPersonByExternalRefIdCommand : UpdateJudiciaryPersonCommandBase
     {
-        public UpdateJudiciaryPersonByExternalRefIdCommand(Guid externalRefId, bool leaver) :
+        public UpdateJudiciaryPersonByExternalRefIdCommand(string externalRefId, bool leaver) :
             base(externalRefId, leaver)
         {
         }

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateJudiciaryPersonCommandBase.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateJudiciaryPersonCommandBase.cs
@@ -6,13 +6,13 @@ namespace BookingsApi.DAL.Commands
 
     public abstract class UpdateJudiciaryPersonCommandBase : ICommand
     {
-        protected UpdateJudiciaryPersonCommandBase(Guid externalRefId, bool hasLeft)
+        protected UpdateJudiciaryPersonCommandBase(string externalRefId, bool hasLeft)
         {
             ExternalRefId = externalRefId;
             HasLeft = hasLeft;
         }
 
-        public Guid ExternalRefId { get; }
+        public string ExternalRefId { get; }
         public bool HasLeft { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.DAL/Migrations/20220616100009_ChangeJudiciaryPersonExternalRefIdToString.Designer.cs
+++ b/BookingsApi/BookingsApi.DAL/Migrations/20220616100009_ChangeJudiciaryPersonExternalRefIdToString.Designer.cs
@@ -5,14 +5,16 @@ using BookingsApi.Domain.Enumerations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BookingsApi.DAL.Migrations
 {
     [DbContext(typeof(BookingsDbContext))]
-    partial class BookingsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220616100009_ChangeJudiciaryPersonExternalRefIdToString")]
+    partial class ChangeJudiciaryPersonExternalRefIdToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookingsApi/BookingsApi.DAL/Migrations/20220616100009_ChangeJudiciaryPersonExternalRefIdToString.cs
+++ b/BookingsApi/BookingsApi.DAL/Migrations/20220616100009_ChangeJudiciaryPersonExternalRefIdToString.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BookingsApi.DAL.Migrations
+{
+    public partial class ChangeJudiciaryPersonExternalRefIdToString : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_JudiciaryPerson_ExternalRefId",
+                table: "JudiciaryPerson");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalRefId",
+                table: "JudiciaryPerson",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JudiciaryPerson_ExternalRefId",
+                table: "JudiciaryPerson",
+                column: "ExternalRefId",
+                unique: true,
+                filter: "[ExternalRefId] IS NOT NULL");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_JudiciaryPerson_ExternalRefId",
+                table: "JudiciaryPerson");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ExternalRefId",
+                table: "JudiciaryPerson",
+                type: "uniqueidentifier",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JudiciaryPerson_ExternalRefId",
+                table: "JudiciaryPerson",
+                column: "ExternalRefId",
+                unique: true);
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Queries/GetJudiciaryPersonByExternalRefIdQuery.cs
+++ b/BookingsApi/BookingsApi.DAL/Queries/GetJudiciaryPersonByExternalRefIdQuery.cs
@@ -8,9 +8,9 @@ namespace BookingsApi.DAL.Queries
 {
     public class GetJudiciaryPersonByExternalRefIdQuery : IQuery
     {
-        public Guid ExternalRefId { get; set; }
+        public string ExternalRefId { get; set; }
 
-        public GetJudiciaryPersonByExternalRefIdQuery(Guid externalRefId)
+        public GetJudiciaryPersonByExternalRefIdQuery(string externalRefId)
         {
             ExternalRefId = externalRefId;
         }

--- a/BookingsApi/BookingsApi.Domain/JudiciaryPerson.cs
+++ b/BookingsApi/BookingsApi.Domain/JudiciaryPerson.cs
@@ -6,7 +6,7 @@ namespace BookingsApi.Domain
     public class JudiciaryPerson : AggregateRoot<Guid>
     {
         private readonly DateTime _currentUTC = DateTime.UtcNow;
-        public JudiciaryPerson(Guid externalRefId, string personalCode, string title, string knownAs, string surname,
+        public JudiciaryPerson(string externalRefId, string personalCode, string title, string knownAs, string surname,
             string fullname, string postNominals, string email, bool hasLeft, bool leaver, string leftOn)
         {
             Id = Guid.NewGuid();
@@ -25,7 +25,7 @@ namespace BookingsApi.Domain
             LeftOn = leftOn;
         }
 
-        public Guid ExternalRefId { get; set; }
+        public string ExternalRefId { get; set; }
         public string PersonalCode { get; set; }
         public string Title { get; set; }
         public string KnownAs { get; set; }

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/AddJudiciaryPersonByExternalRefIdCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/AddJudiciaryPersonByExternalRefIdCommandTests.cs
@@ -24,7 +24,7 @@ namespace BookingsApi.IntegrationTests.Database.Commands
         [Test]
         public async Task should_add_person()
         {
-            var externalRefId = Guid.NewGuid();
+            var externalRefId = Guid.NewGuid().ToString();
 
             var insertCommand = new AddJudiciaryPersonByExternalRefIdCommand(externalRefId, "PersonalCode", "Title", "KnownAs", "Surname", "FullName", "PostNominals", "Email", true, true, "2022-06-08");
             await _commandHandler.Handle(insertCommand);

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/AddJudiciaryPersonCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/AddJudiciaryPersonCommandTests.cs
@@ -24,7 +24,7 @@ namespace BookingsApi.IntegrationTests.Database.Commands
         [Test]
         public async Task should_add_non_leaver_person()
         {
-            var externalRefId = Guid.NewGuid();
+            var externalRefId = Guid.NewGuid().ToString();
             var addCommand = new AddJudiciaryPersonCommand(externalRefId, "PersonalCode", "Title", "KnownAs", "Surname", "FullName", "PostNominals", "Email", false, false, string.Empty);
             
             await _commandHandler.Handle(addCommand);
@@ -48,7 +48,7 @@ namespace BookingsApi.IntegrationTests.Database.Commands
         [Test]
         public async Task should_add_leaver_person()
         {
-            var externalRefId = Guid.NewGuid();
+            var externalRefId = Guid.NewGuid().ToString();
             var addCommand = new AddJudiciaryPersonCommand(externalRefId, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, false, true, "2022-06-08");
             
             await _commandHandler.Handle(addCommand);

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateJudiciaryLeaverByExternalRefIdCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateJudiciaryLeaverByExternalRefIdCommandTests.cs
@@ -25,14 +25,14 @@ namespace BookingsApi.IntegrationTests.Database.Commands
         [Test]
         public void should_throw_exception_when_peron_does_not_exist()
         {
-            var command = new UpdateJudiciaryLeaverByExternalRefIdCommand(Guid.NewGuid(),true);
+            var command = new UpdateJudiciaryLeaverByExternalRefIdCommand(Guid.NewGuid().ToString(),true);
             Assert.ThrowsAsync<JudiciaryLeaverNotFoundException>(() => _commandHandler.Handle(command));
         }
         
         [Test]
         public async Task should_update_person()
         {
-            var externalRefId = Guid.NewGuid();
+            var externalRefId = Guid.NewGuid().ToString();
             await Hooks.AddJudiciaryPerson(externalRefId);
 
             var updateCommand = new UpdateJudiciaryLeaverByExternalRefIdCommand(externalRefId, true);

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateJudiciaryPersonByExternalRefIdCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateJudiciaryPersonByExternalRefIdCommandTests.cs
@@ -25,14 +25,14 @@ namespace BookingsApi.IntegrationTests.Database.Commands
         [Test]
         public void should_throw_exception_when_peron_does_not_exist()
         {
-            var command = new UpdateJudiciaryPersonByExternalRefIdCommand(Guid.NewGuid(), false);
+            var command = new UpdateJudiciaryPersonByExternalRefIdCommand(Guid.NewGuid().ToString(), false);
             Assert.ThrowsAsync<JudiciaryPersonNotFoundException>(() => _commandHandler.Handle(command));
         }
         
         [Test]
         public async Task should_update_person()
         {
-            var externalRefId = Guid.NewGuid();
+            var externalRefId = Guid.NewGuid().ToString();
             await Hooks.AddJudiciaryPerson(externalRefId);
 
             var updateCommand = new UpdateJudiciaryPersonByExternalRefIdCommand(externalRefId, true);

--- a/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
@@ -25,7 +25,7 @@ namespace BookingsApi.IntegrationTests.Helper
     {
         private readonly DbContextOptions<BookingsDbContext> _dbContextOptions;
         private readonly List<Guid> _seededHearings = new List<Guid>();
-        public List<Guid> JudiciaryPersons { get; } = new List<Guid>();
+        public List<string> JudiciaryPersons { get; } = new List<string>();
         public string CaseNumber { get; } = "2222/3511";
         private Guid _individualId;
         private List<Guid> _participantRepresentativeIds;
@@ -36,7 +36,7 @@ namespace BookingsApi.IntegrationTests.Helper
             _seededHearings.Add(id);
         }
         
-        public void AddJudiciaryPersonsForCleanup(params Guid[] ids)
+        public void AddJudiciaryPersonsForCleanup(params string[] ids)
         {
             JudiciaryPersons.AddRange(ids);
         }
@@ -579,7 +579,7 @@ namespace BookingsApi.IntegrationTests.Helper
             return hearing;
         }
         
-        public async Task AddJudiciaryPerson(Guid? externalRefId = null)
+        public async Task AddJudiciaryPerson(string externalRefId = null)
         {
             await using var db = new BookingsDbContext(_dbContextOptions);
 

--- a/BookingsApi/BookingsApi.IntegrationTests/Steps/JudiciaryPersonsSteps.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Steps/JudiciaryPersonsSteps.cs
@@ -45,9 +45,9 @@ namespace BookingsApi.IntegrationTests.Steps
         {
             return new List<JudiciaryPersonRequest>
             {
-                new JudiciaryPersonRequest {Id = Guid.NewGuid(), Email = "test.email.com", Fullname = "ccc ddd", KnownAs = "ccc", Surname = "ddd", Title = "mr", PersonalCode = "123", PostNominals = "postnom1"},
-                new JudiciaryPersonRequest {Id = Guid.NewGuid(), Email = "test.email.com", Fullname = "eee fff", KnownAs = "eee", Surname = "fff", Title = "mr", PersonalCode = "123", PostNominals = "postnom1"},
-                new JudiciaryPersonRequest {Id = Guid.NewGuid(), Email = "test.email.com", Fullname = "ggg hhh", KnownAs = "ggg", Surname = "hhh", Title = "mr", PersonalCode = "123", PostNominals = "postnom1"}
+                new JudiciaryPersonRequest {Id = Guid.NewGuid().ToString(), Email = "test.email.com", Fullname = "ccc ddd", KnownAs = "ccc", Surname = "ddd", Title = "mr", PersonalCode = "123", PostNominals = "postnom1"},
+                new JudiciaryPersonRequest {Id = Guid.NewGuid().ToString(), Email = "test.email.com", Fullname = "eee fff", KnownAs = "eee", Surname = "fff", Title = "mr", PersonalCode = "123", PostNominals = "postnom1"},
+                new JudiciaryPersonRequest {Id = Guid.NewGuid().ToString(), Email = "test.email.com", Fullname = "ggg hhh", KnownAs = "ggg", Surname = "hhh", Title = "mr", PersonalCode = "123", PostNominals = "postnom1"}
             };
         }
     }

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/JudiciaryPersonControllerTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/JudiciaryPersonControllerTests.cs
@@ -58,7 +58,7 @@ namespace BookingsApi.UnitTests.Controllers
         [Test]
         public async Task Should_return_ok_result_adding_item()
         {
-            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1" };
+            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid().ToString(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1" };
             var request = new List<JudiciaryPersonRequest> { item1 };
 
             _queryHandlerMock
@@ -86,7 +86,7 @@ namespace BookingsApi.UnitTests.Controllers
         [Test]
         public async Task Should_return_ok_result_adding_leaver_person()
         {
-            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid(), Leaver = true, LeftOn = "2022-06-08"};
+            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid().ToString(), Leaver = true, LeftOn = "2022-06-08"};
             var request = new List<JudiciaryPersonRequest> { item1 };
 
             _queryHandlerMock
@@ -112,7 +112,7 @@ namespace BookingsApi.UnitTests.Controllers
         [Test]
         public async Task Should_return_ok_result_updating_leaver_item()
         {
-            var id = Guid.NewGuid();
+            var id = Guid.NewGuid().ToString();
             var judiciaryPerson = new JudiciaryPerson(id, "some@email.com", "a", "b", "c", "d", "123", "nom1", false, false, string.Empty);
             var item1 = new JudiciaryLeaverRequest { Id = id.ToString(), Leaver = true, LeftOn = DateTime.Now.AddDays(-100).ToLongDateString() };
 
@@ -247,7 +247,7 @@ namespace BookingsApi.UnitTests.Controllers
         [Test]
         public async Task Should_return_ok_result_updating_item()
         {
-            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1", HasLeft = true };
+            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid().ToString(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1", HasLeft = true };
             var retrievedPerson1 = new JudiciaryPerson(item1.Id, item1.PersonalCode, item1.Title, item1.KnownAs, item1.Surname, item1.Fullname, item1.PostNominals, item1.Email, item1.HasLeft, false, string.Empty);
             var request = new List<JudiciaryPersonRequest> { item1 };
 
@@ -274,8 +274,8 @@ namespace BookingsApi.UnitTests.Controllers
         [Test]
         public async Task Should_return_ok_result_adding_and_updating_item()
         {
-            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1", HasLeft = false };
-            var item2 = new JudiciaryPersonRequest { Id = Guid.NewGuid(), Email = "some2@email.com", Fullname = "a2", Surname = "b2", Title = "c2", KnownAs = "d2", PersonalCode = "456", PostNominals = "nom2", HasLeft = false };
+            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid().ToString(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1", HasLeft = false };
+            var item2 = new JudiciaryPersonRequest { Id = Guid.NewGuid().ToString(), Email = "some2@email.com", Fullname = "a2", Surname = "b2", Title = "c2", KnownAs = "d2", PersonalCode = "456", PostNominals = "nom2", HasLeft = false };
             var retrievedPerson1 = new JudiciaryPerson(item2.Id, item2.PersonalCode, item2.Title, item2.KnownAs, item2.Surname, item2.Fullname, item2.PostNominals, item2.Email, item2.HasLeft, false, string.Empty);
             var request = new List<JudiciaryPersonRequest> { item1, item2 };
 
@@ -341,7 +341,7 @@ namespace BookingsApi.UnitTests.Controllers
         {
             var requestNoEmail = new JudiciaryPersonRequest
             {
-                Id = Guid.NewGuid(),
+                Id = Guid.NewGuid().ToString(),
                 Fullname = "a",
                 Surname = "b",
                 Title = "c",
@@ -367,7 +367,7 @@ namespace BookingsApi.UnitTests.Controllers
         {
             var requestNoEmail = new JudiciaryPersonRequest
             {
-                Id = Guid.NewGuid(),
+                Id = Guid.NewGuid().ToString(),
                 Fullname = "a",
                 Title = "c",
                 KnownAs = "d",
@@ -393,7 +393,7 @@ namespace BookingsApi.UnitTests.Controllers
         {
             var requestNoEmail = new JudiciaryPersonRequest
             {
-                Id = Guid.NewGuid(),
+                Id = Guid.NewGuid().ToString(),
                 Fullname = "a",
                 Surname = "b",
                 Title = "c",
@@ -417,7 +417,7 @@ namespace BookingsApi.UnitTests.Controllers
         [Test]
         public async Task Should_return_error_items_in_request_exception()
         {
-            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1" };
+            var item1 = new JudiciaryPersonRequest { Id = Guid.NewGuid().ToString(), Email = "some@email.com", Fullname = "a", Surname = "b", Title = "c", KnownAs = "d", PersonalCode = "123", PostNominals = "nom1" };
             var request = new List<JudiciaryPersonRequest> { item1 };
 
             _queryHandlerMock
@@ -443,8 +443,8 @@ namespace BookingsApi.UnitTests.Controllers
         {
             var searchTermRequest = new SearchTermRequest("test");
             var persons = new List<JudiciaryPerson> {
-                                new JudiciaryPerson(Guid.NewGuid(),"CODE1","Mr", "Test", "Tester", "T Tester", "N", "test@hmcts.net", false, false, string.Empty),
-                                new JudiciaryPerson(Guid.NewGuid(), "CODE", "Mr", "Tester", "Test", "T Test", "n1", "atest@hmcts.net", false, false, string.Empty)
+                                new JudiciaryPerson(Guid.NewGuid().ToString(),"CODE1","Mr", "Test", "Tester", "T Tester", "N", "test@hmcts.net", false, false, string.Empty),
+                                new JudiciaryPerson(Guid.NewGuid().ToString(), "CODE", "Mr", "Tester", "Test", "T Test", "n1", "atest@hmcts.net", false, false, string.Empty)
             };
             _queryHandlerMock
            .Setup(x => x.Handle<GetJudiciaryPersonBySearchTermQuery, List<JudiciaryPerson>>(It.IsAny<GetJudiciaryPersonBySearchTermQuery>()))

--- a/BookingsApi/BookingsApi.UnitTests/Domain/JudiciaryPersons/UpdateJudiciaryPersonTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/JudiciaryPersons/UpdateJudiciaryPersonTests.cs
@@ -10,7 +10,7 @@ namespace BookingsApi.UnitTests.Domain.JudiciaryPersons
         [Test]
         public void Should_update_person()
         {
-            var person = new JudiciaryPerson(Guid.NewGuid(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", true, false, string.Empty);
+            var person = new JudiciaryPerson(Guid.NewGuid().ToString(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", true, false, string.Empty);
             person.Update("PersonalCode", "Title", "KnownAs", "Surname", "FullName", "PostNominals", "Email", true, true, "2022-06-08");
 
             person.PersonalCode.Should().Be("PersonalCode");
@@ -28,7 +28,7 @@ namespace BookingsApi.UnitTests.Domain.JudiciaryPersons
         [Test]
         public void Should_update_the_leaver_person()
         {
-            var person = new JudiciaryPerson(Guid.NewGuid(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", false, false, string.Empty);
+            var person = new JudiciaryPerson(Guid.NewGuid().ToString(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", false, false, string.Empty);
             person.Update(true);
             
             person.HasLeft.Should().BeTrue();
@@ -38,7 +38,7 @@ namespace BookingsApi.UnitTests.Domain.JudiciaryPersons
         [Test]
         public void Should_set_personal_data_to_null_for_leaver_accounts()
         {
-            var person = new JudiciaryPerson(Guid.NewGuid(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", false, true, "1-1-2020");
+            var person = new JudiciaryPerson(Guid.NewGuid().ToString(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", false, true, "1-1-2020");
             person.Update(true);
 
             person.HasLeft.Should().BeTrue();
@@ -53,7 +53,7 @@ namespace BookingsApi.UnitTests.Domain.JudiciaryPersons
         [Test]
         public void Should_not_set_personal_data_to_null_for_leaver_accounts()
         {
-            var person = new JudiciaryPerson(Guid.NewGuid(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", false, true, "1-1-2020");
+            var person = new JudiciaryPerson(Guid.NewGuid().ToString(), "123", "Mr", "Steve", "Allen", "Steve Allen", "nom1", "email1@email.com", false, true, "1-1-2020");
             person.Update(false);
 
             person.HasLeft.Should().BeFalse();

--- a/BookingsApi/BookingsApi/Controllers/JudiciaryPersonController.cs
+++ b/BookingsApi/BookingsApi/Controllers/JudiciaryPersonController.cs
@@ -123,12 +123,12 @@ namespace BookingsApi.Controllers
 
                 try
                 {
-                    var query = new GetJudiciaryPersonByExternalRefIdQuery(Guid.Parse(item.Id));
+                    var query = new GetJudiciaryPersonByExternalRefIdQuery(item.Id);
                     var judiciaryPerson = await _queryHandler.Handle<GetJudiciaryPersonByExternalRefIdQuery, JudiciaryPerson>(query);
 
                     if (judiciaryPerson != null)
                     {
-                        await _commandHandler.Handle(new UpdateJudiciaryLeaverByExternalRefIdCommand(Guid.Parse(item.Id), item.Leaver));
+                        await _commandHandler.Handle(new UpdateJudiciaryLeaverByExternalRefIdCommand(item.Id, item.Leaver));
                     }
                     else
                     {

--- a/BookingsApi/Testing.Common/Builders/Domain/JudiciaryPersonBuilder.cs
+++ b/BookingsApi/Testing.Common/Builders/Domain/JudiciaryPersonBuilder.cs
@@ -9,12 +9,12 @@ namespace Testing.Common.Builders.Domain
     {
         private readonly JudiciaryPerson _judiciaryPerson;
 
-        public JudiciaryPersonBuilder(Guid? externalRefId = null)
+        public JudiciaryPersonBuilder(string externalRefId = null)
         {
             var settings = new BuilderSettings();
             _judiciaryPerson = new Builder(settings).CreateNew<JudiciaryPerson>().WithFactory(() =>
                     new JudiciaryPerson(
-                        externalRefId ?? Guid.NewGuid(),
+                        externalRefId,
                         $"{RandomNumber.Next(0, 1000)}",
                         Name.Prefix(),
                         $"Automation_{Name.First()}",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,6 @@ extends:
     nugetProjectPath: BookingsApi/BookingsApi.Client
     PackageNuget: ${{ parameters.PackageNuget }}
     PackageApp: ${{ parameters.PackageApp }}
-
     PackageAcceptanceTests: ${{ parameters.PackageACTests }}
     Test: ${{ or(parameters.RunUnitTests, parameters.RunIntegTests, parameters.RunMutationTests) }}
     connectionStringSecretName: "VhBookingsDatabaseConnectionString"
@@ -153,7 +152,6 @@ extends:
       baseAgent: windows-latest
       coreProjectPath: BookingsApi/BookingsApi
       nugetConfigPath: BookingsApi
-      dotnetEfVersion: '6.0.5'
       unitTestProjectPath: BookingsApi/BookingsApi.UnitTests
       integTestProjectPath: BookingsApi/BookingsApi.IntegrationTests
       secrets_KeyVault: $(pr_Secret_KeyVault)
@@ -183,7 +181,6 @@ extends:
     ACTest: ${{ parameters.RunACTests }}
     releaseParameters:
       environment: Preview
-      dotnetEfVersion: '6.0.5'
       subscription: $(pr_Subscription)
       secrets_KeyVault: $(pr_Secret_KeyVault)
       secrets_Subscription: $(pr_Secret_Subscription)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,6 +145,7 @@ extends:
     nugetProjectPath: BookingsApi/BookingsApi.Client
     PackageNuget: ${{ parameters.PackageNuget }}
     PackageApp: ${{ parameters.PackageApp }}
+
     PackageAcceptanceTests: ${{ parameters.PackageACTests }}
     Test: ${{ or(parameters.RunUnitTests, parameters.RunIntegTests, parameters.RunMutationTests) }}
     connectionStringSecretName: "VhBookingsDatabaseConnectionString"
@@ -152,6 +153,7 @@ extends:
       baseAgent: windows-latest
       coreProjectPath: BookingsApi/BookingsApi
       nugetConfigPath: BookingsApi
+      dotnetEfVersion: '6.0.5'
       unitTestProjectPath: BookingsApi/BookingsApi.UnitTests
       integTestProjectPath: BookingsApi/BookingsApi.IntegrationTests
       secrets_KeyVault: $(pr_Secret_KeyVault)
@@ -181,6 +183,7 @@ extends:
     ACTest: ${{ parameters.RunACTests }}
     releaseParameters:
       environment: Preview
+      dotnetEfVersion: '6.0.5'
       subscription: $(pr_Subscription)
       secrets_KeyVault: $(pr_Secret_KeyVault)
       secrets_Subscription: $(pr_Secret_Subscription)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9109


### Change description ###
Sometimes the deserialisation of the eLinks People API response fails, this is because the Id is a uuid and we are casting it to a Guid.

Instead, store it as string.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
