### PR TITLE
VIH-9161 Fix issue with users not being added to AD groups

### DIFF
--- a/BookingsApi/BookingsApi.UnitTests/Mappings/ParticipantRequestToNewParticipantMapperTest.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Mappings/ParticipantRequestToNewParticipantMapperTest.cs
@@ -85,7 +85,37 @@ namespace BookingsApi.UnitTests.Mappings
             newParticipant.Should().NotBeNull();
             var person = newParticipant.Person;
             person.Should().NotBeNull();
-            person.Organisation.Should().NotBeNull();
+            person.Title.Should().Be("Mr");
+            person.FirstName.Should().Be("Test");
+            person.LastName.Should().Be("Tester");
+            person.Username.Should().Be("TestTester");
+            person.ContactEmail.Should().Be("contact@contact.com");
+            person.Organisation.Name.Should().Be("Test Corp Ltd");
+
+            var caseRole = newParticipant.CaseRole;
+            caseRole.Name.Should().Be("Respondent");
+        }
+
+        [Test]
+        public void Should_map_username_to_contact_email_when_username_empty()
+        {
+            var request = new ParticipantRequest
+            {
+                Title = "Mr",
+                FirstName = "Test",
+                LastName = "Tester",
+                Username = "",
+                CaseRoleName = "Respondent",
+                HearingRoleName = "Representative",
+                OrganisationName = "Test Corp Ltd",
+                ContactEmail = "contact@contact.com"
+            };
+            
+            var newParticipant = ParticipantRequestToNewParticipantMapper.Map(request, _caseType);
+            newParticipant.Should().NotBeNull();
+            var person = newParticipant.Person;
+            person.ContactEmail.Should().Be("contact@contact.com");
+            person.Username.Should().Be("contact@contact.com");
         }
     }
 }

--- a/BookingsApi/BookingsApi/Mappings/ParticipantRequestToNewParticipantMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/ParticipantRequestToNewParticipantMapper.cs
@@ -20,15 +20,14 @@ namespace BookingsApi.Mappings
 
             var hearingRole = caseRole.HearingRoles.FirstOrDefault(x => x.Name == requestParticipant.HearingRoleName);
             if (hearingRole == null) throw new BadRequestException($"Invalid hearing role [{requestParticipant.HearingRoleName}]");
-            
-            if (requestParticipant.HearingRoleName != "Judge" || !string.IsNullOrEmpty(requestParticipant.Username)
-                && (requestParticipant.HearingRoleName == "PanelMember" || requestParticipant.HearingRoleName == "Winger"))
+
+            if (string.IsNullOrEmpty(requestParticipant.Username))
             {
                 requestParticipant.Username = requestParticipant.ContactEmail;
             }
             
             var person = new Person(requestParticipant.Title, requestParticipant.FirstName, requestParticipant.LastName,
-                requestParticipant.Username, requestParticipant.ContactEmail)
+                requestParticipant.ContactEmail, requestParticipant.Username)
             {
                 MiddleNames = requestParticipant.MiddleNames,
                 ContactEmail = requestParticipant.ContactEmail,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9161


### Change description ###
Fixes an issue where upon creating a new user as part of a booking, the user is not added into any AD groups.

This is due to the username being set to the contact email, resulting in a failed Azure AD lookup.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
