### PR TITLE
VIH-9228 Unable to remove party from hearing

### DIFF
--- a/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
@@ -592,8 +592,11 @@ namespace BookingsApi.Controllers
                 }
                 else
                 {
-                    await _eventPublisher.PublishAsync(new CreateAndNotifyUserIntegrationEvent(hearing, eventNewParticipants));
-                    await _eventPublisher.PublishAsync(new HearingNotificationIntegrationEvent(hearing, eventNewParticipants));
+                    if (eventNewParticipants.Any())
+                    {
+                        await _eventPublisher.PublishAsync(new CreateAndNotifyUserIntegrationEvent(hearing, eventNewParticipants));
+                        await _eventPublisher.PublishAsync(new HearingNotificationIntegrationEvent(hearing, eventNewParticipants));   
+                    }
                 }
             }
         }

--- a/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
@@ -559,40 +559,42 @@ namespace BookingsApi.Controllers
         {
             var eventNewParticipants = hearing.GetParticipants()
                         .Where(x => newParticipants.Any(y => y.Person.ContactEmail == x.Person.ContactEmail)).ToList();
-
-            if (hearing.Status == BookingStatus.Created)
+            if (eventNewParticipants.Any() || removedParticipantIds.Any())
             {
-                var eventExistingParticipants = hearing.GetParticipants()
-                    .Where(x => existingParticipants.Any(y => y.ParticipantId == x.Id)).ToList();
-            
-                var eventLinkedParticipants = new List<Infrastructure.Services.Dtos.LinkedParticipantDto>();
-            
-                foreach (var linkedParticipant in linkedParticipants)
+                if (hearing.Status == BookingStatus.Created)
                 {
-                    var primaryLinkedParticipant = hearing.GetParticipants().SingleOrDefault(x => x.Person.ContactEmail == linkedParticipant.ParticipantContactEmail);
-                    var secondaryLinkedParticipant = hearing.GetParticipants().SingleOrDefault(x => x.Person.ContactEmail == linkedParticipant.LinkedParticipantContactEmail);
-            
-                    eventLinkedParticipants.Add(new Infrastructure.Services.Dtos.LinkedParticipantDto
+                    var eventExistingParticipants = hearing.GetParticipants()
+                        .Where(x => existingParticipants.Any(y => y.ParticipantId == x.Id)).ToList();
+                
+                    var eventLinkedParticipants = new List<Infrastructure.Services.Dtos.LinkedParticipantDto>();
+                
+                    foreach (var linkedParticipant in linkedParticipants)
                     {
-                        LinkedId = secondaryLinkedParticipant.Id,
-                        ParticipantId = primaryLinkedParticipant.Id,
-                        Type = linkedParticipant.Type
-                    });
+                        var primaryLinkedParticipant = hearing.GetParticipants().SingleOrDefault(x => x.Person.ContactEmail == linkedParticipant.ParticipantContactEmail);
+                        var secondaryLinkedParticipant = hearing.GetParticipants().SingleOrDefault(x => x.Person.ContactEmail == linkedParticipant.LinkedParticipantContactEmail);
+                
+                        eventLinkedParticipants.Add(new Infrastructure.Services.Dtos.LinkedParticipantDto
+                        {
+                            LinkedId = secondaryLinkedParticipant.Id,
+                            ParticipantId = primaryLinkedParticipant.Id,
+                            Type = linkedParticipant.Type
+                        });
+                    }
+                
+                    var hearingParticipantsUpdatedIntegrationEvent = new HearingParticipantsUpdatedIntegrationEvent(hearing, eventExistingParticipants, eventNewParticipants,
+                        removedParticipantIds, eventLinkedParticipants);
+                    await _eventPublisher.PublishAsync(hearingParticipantsUpdatedIntegrationEvent);
                 }
-            
-                var hearingParticipantsUpdatedIntegrationEvent = new HearingParticipantsUpdatedIntegrationEvent(hearing, eventExistingParticipants, eventNewParticipants,
-                    removedParticipantIds, eventLinkedParticipants);
-                await _eventPublisher.PublishAsync(hearingParticipantsUpdatedIntegrationEvent);
-            }
-            else if (eventNewParticipants.Any(x => x.HearingRole.UserRole.Name == "Judge"))
-            {
-                await UpdateHearingStatusAsync(hearing.Id, BookingStatus.Created, "System", string.Empty);
-                await _eventPublisher.PublishAsync(new HearingIsReadyForVideoIntegrationEvent(hearing, eventNewParticipants));
-            }
-            else
-            {
-                await _eventPublisher.PublishAsync(new CreateAndNotifyUserIntegrationEvent(hearing, eventNewParticipants));
-                await _eventPublisher.PublishAsync(new HearingNotificationIntegrationEvent(hearing, eventNewParticipants));
+                else if (eventNewParticipants.Any(x => x.HearingRole.UserRole.Name == "Judge"))
+                {
+                    await UpdateHearingStatusAsync(hearing.Id, BookingStatus.Created, "System", string.Empty);
+                    await _eventPublisher.PublishAsync(new HearingIsReadyForVideoIntegrationEvent(hearing, eventNewParticipants));
+                }
+                else
+                {
+                    await _eventPublisher.PublishAsync(new CreateAndNotifyUserIntegrationEvent(hearing, eventNewParticipants));
+                    await _eventPublisher.PublishAsync(new HearingNotificationIntegrationEvent(hearing, eventNewParticipants));
+                }
             }
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9228


### Change description ###
Fixes an issue where removing participants from a hearing removes them from bookings API but not video API.

This is due to the hearing participants updated event not being published in this scenario.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
