### PR TITLE
VIH-9257 Support slashes in email addresses

### DIFF
--- a/BookingsApi/BookingsApi.IntegrationTests/Features/Persons.feature
+++ b/BookingsApi/BookingsApi.IntegrationTests/Features/Persons.feature
@@ -119,3 +119,10 @@ Feature: Persons
     And I have a valid update person details request
     When I send the request to the endpoint
     Then the response should have the status Accepted and success status True
+   
+  Scenario: Update username for a person with valid details containing a slash
+    Given I have a hearing
+    And I have a valid update username request containing a slash
+    When I send the request to the endpoint
+    Then the response should have the status NoContent and success status True
+    

--- a/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
@@ -14,6 +14,7 @@ using BookingsApi.Domain;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.Participants;
 using BookingsApi.Domain.RefData;
+using Faker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
@@ -84,6 +85,7 @@ namespace BookingsApi.IntegrationTests.Helper
             var person2 = new PersonBuilder(true).Build();
             var person3 = new PersonBuilder(true).Build();
             var person4 = new PersonBuilder(true).Build();
+            var person5 = new PersonBuilder($"Automation/{RandomNumber.Next()}@hmcts.net").Build();
             var judgePerson = new PersonBuilder(true).Build();
             var johPerson = new PersonBuilder(true).Build();
             var scheduledDate = options.ScheduledDate ?? DateTime.Today.AddDays(1).AddHours(10).AddMinutes(30);
@@ -111,6 +113,9 @@ namespace BookingsApi.IntegrationTests.Helper
             videoHearing.AddIndividual(person4, respondentLipHearingRole, respondentCaseRole,
                 $"{person4.FirstName} {person4.LastName}");
 
+            videoHearing.AddIndividual(person5, applicantLipHearingRole, applicantCaseRole,
+                $"{person5.FirstName} {person5.LastName}");
+            
             videoHearing.AddJudge(judgePerson, judgeHearingRole, judgeCaseRole, $"{judgePerson.FirstName} {judgePerson.LastName}");
 
             if (addJoh)

--- a/BookingsApi/BookingsApi.IntegrationTests/Steps/PersonsSteps.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Steps/PersonsSteps.cs
@@ -204,6 +204,17 @@ namespace BookingsApi.IntegrationTests.Steps
             var jsonBody = RequestHelper.Serialise(request);
             Context.HttpContent = new StringContent(jsonBody, Encoding.UTF8, "application/json");
         }
+
+        [Given(@"I have a valid update username request containing a slash")]
+        public void GivenIHaveAValidUpdateUsernameRequestContainingASlash()
+        {
+            var hearing = Context.TestData.SeededHearing;
+            var person = hearing.GetPersons().First((p => p.ContactEmail.Contains(("/"))));
+            var contactEmail = person.ContactEmail;
+            var username = person.ContactEmail;
+            Context.Uri = UpdatePersonUsername(contactEmail, username);
+            Context.HttpMethod = HttpMethod.Put;
+        }
         
         private void SetupGetHearingsByUsernameForDeletionRequest(string username)
         {

--- a/BookingsApi/BookingsApi/Controllers/PersonsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/PersonsController.cs
@@ -370,7 +370,7 @@ namespace BookingsApi.Controllers
         /// <param name="contactEmail">The contact email of the person</param>
         /// <param name="username">username of the person</param>
         /// <returns>No content</returns>
-        [HttpPut("user/{contactEmail}", Name = "UpdatePersonUsername")]
+        [HttpPut("user/{**contactEmail}", Name = "UpdatePersonUsername")]
         [OpenApiOperation("UpdatePersonUsername")]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]

--- a/BookingsApi/BookingsApi/Controllers/PersonsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/PersonsController.cs
@@ -109,7 +109,7 @@ namespace BookingsApi.Controllers
         /// </summary>
         /// <param name="contactEmail">The contact email of the person</param>
         /// <returns>Person</returns>
-        [HttpGet("contactEmail/{contactEmail}", Name = "GetPersonByContactEmail")]
+        [HttpGet("contactEmail/{**contactEmail}", Name = "GetPersonByContactEmail")]
         [OpenApiOperation("GetPersonByContactEmail")]
         [ProducesResponseType(typeof(PersonResponse), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]

--- a/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
+++ b/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
@@ -64,6 +64,7 @@ namespace Testing.Common.Builders.Api
             public static string AnonymisePerson(string username) => $"{ApiRoot}/username/{username}/anonymise";
             public static string SearchForNonJudicialPersonsByContactEmail(string contactEmail) => $"{ApiRoot}/?contactEmail={contactEmail}";
             public static string UpdatePersonDetails(Guid personId) => $"{ApiRoot}/{personId}";
+            public static string UpdatePersonUsername(string contactEmail, string username) => $"{ApiRoot}/user/{contactEmail}?username={username}";
         }
 
         public static class SuitabilityAnswerEndpoints

--- a/BookingsApi/Testing.Common/Builders/Domain/PersonBuilder.cs
+++ b/BookingsApi/Testing.Common/Builders/Domain/PersonBuilder.cs
@@ -32,6 +32,14 @@ namespace Testing.Common.Builders.Domain
                 .Build();
         }
 
+        public PersonBuilder(string contactEmail)
+        {
+            var settings = new BuilderSettings();
+            _person = new Builder(settings).CreateNew<Person>().WithFactory(() =>
+                    new Person(Name.Prefix(), $"Automation_{Name.First()}", $"Automation_{Name.Last()}", contactEmail, contactEmail))
+                .Build();
+        }
+
         public PersonBuilder WithOrganisation()
         {
             _person.Organisation = new Builder(_settings).CreateNew<Organisation>()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9257


### Change description ###
Creating a hearing with participants containing slashes in their email address currently fails as the slash doesn't get url decoded, causing the user lookups to fail.

Fix by changing the contactEmail to a catch-all parameter (**) which supports slashes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
