### PR TITLE
VIH-9417 - Toggle eJudFeature moved to Launch Darkly Updated the pipeline

### DIFF
--- a/BookingsApi/BookingsApi.Common/Services/FeatureToggles.cs
+++ b/BookingsApi/BookingsApi.Common/Services/FeatureToggles.cs
@@ -10,6 +10,7 @@ namespace BookingsApi.Common.Services
     {
         public bool AdminSearchToggle();
         public bool ReferenceDataToggle();
+        public bool EJudFeature();
     }
 
     public class FeatureToggles : IFeatureToggles
@@ -19,6 +20,7 @@ namespace BookingsApi.Common.Services
         private const string LdUser = "vh-booking-api";
         private const string AdminSearchToggleKey = "admin_search";
         private const string ReferenceDataToggleKey = "reference-data";
+        private const string EJudFeatureKey = "ejud-feature";
         public FeatureToggles(string sdkKey)
         {
             var config = LaunchDarkly.Sdk.Server.Configuration.Builder(sdkKey)
@@ -32,6 +34,7 @@ namespace BookingsApi.Common.Services
 
         public bool AdminSearchToggle() => _ldClient.BoolVariation(AdminSearchToggleKey, _user);
         public bool ReferenceDataToggle() => _ldClient.BoolVariation(ReferenceDataToggleKey, _user);
+        public bool EJudFeature() => _ldClient.BoolVariation(EJudFeatureKey, _user);
     }
 }
  

--- a/BookingsApi/BookingsApi.Contract/Configuration/FeatureFlagConfiguration.cs
+++ b/BookingsApi/BookingsApi.Contract/Configuration/FeatureFlagConfiguration.cs
@@ -2,8 +2,6 @@
 {
     public class FeatureFlagConfiguration
     {
-        public bool EJudFeature { get; set; }
-
         public bool StaffMemberFeature { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.DAL/Queries/GetPersonBySearchTermQuery.cs
+++ b/BookingsApi/BookingsApi.DAL/Queries/GetPersonBySearchTermQuery.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BookingsApi.Common.Services;
 
 namespace BookingsApi.DAL.Queries
 {
@@ -22,19 +23,19 @@ namespace BookingsApi.DAL.Queries
     public class GetPersonBySearchTermQueryHandler : IQueryHandler<GetPersonBySearchTermQuery, List<Person>>
     {
         private readonly BookingsDbContext _context;
-        private readonly FeatureFlagConfiguration _featureFlagConfiguration;
+        private readonly IFeatureToggles _featureToggles;
         public static readonly List<string> excludedRoles = new List<string>() { "Judge", "JudicialOfficeHolder", "StaffMember" };
 
-        public GetPersonBySearchTermQueryHandler(BookingsDbContext context, IOptions<FeatureFlagConfiguration> featureFlagConfigurationOptions)
+        public GetPersonBySearchTermQueryHandler(BookingsDbContext context, IFeatureToggles featureToggles)
         {
             _context = context;
-            _featureFlagConfiguration = featureFlagConfigurationOptions.Value;
+            _featureToggles = featureToggles;
         }
 
         public async Task<List<Person>> Handle(GetPersonBySearchTermQuery query)
         {
             List<Person> results;
-            if (_featureFlagConfiguration.EJudFeature)
+            if (_featureToggles.EJudFeature())
             {
                 results = await (from person in _context.Persons
                                  join participant in _context.Participants on person.Id equals participant.PersonId

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetPersonBySearchTermQueryHandlerDatabaseTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetPersonBySearchTermQueryHandlerDatabaseTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
+using BookingsApi.Common.Services;
 
 namespace BookingsApi.IntegrationTests.Database.Queries
 {
@@ -14,18 +15,21 @@ namespace BookingsApi.IntegrationTests.Database.Queries
     {
         private GetPersonBySearchTermQueryHandler _handler;
         private Mock<IOptions<FeatureFlagConfiguration>> _configOptions;
+        private Mock<IFeatureToggles> _featureToggles;
 
 
         [SetUp]
         public void Setup()
         {
             _configOptions = new Mock<IOptions<FeatureFlagConfiguration>>();
+            _featureToggles = new Mock<IFeatureToggles>();
             var context = new BookingsDbContext(BookingsDbContextOptions);
             _configOptions.Setup(opt => opt.Value).Returns(new FeatureFlagConfiguration()
             {
                 StaffMemberFeature = true
             });
-            _handler = new GetPersonBySearchTermQueryHandler(context, _configOptions.Object);
+            _featureToggles.Setup(toggle => toggle.EJudFeature()).Returns(false);
+            _handler = new GetPersonBySearchTermQueryHandler(context, _featureToggles.Object);
         }
 
         [Test]

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetPersonBySearchTermQueryHandlerEFCoreTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetPersonBySearchTermQueryHandlerEFCoreTests.cs
@@ -78,6 +78,8 @@ namespace BookingsApi.IntegrationTests.Database.Queries
         [Test]
         public async Task Returns_Persons_Record_By_Search_Term_EJjud_ON()
         {
+            _featureToggles.Setup(toggle => toggle.EJudFeature()).Returns(true);
+            _handler = new GetPersonBySearchTermQueryHandler(_context, _featureToggles.Object);
             var persons = await _handler.Handle(new GetPersonBySearchTermQuery("luff"));
 
             Assert.AreEqual(1, persons.Count);
@@ -89,7 +91,7 @@ namespace BookingsApi.IntegrationTests.Database.Queries
         [Test]
         public async Task Returns_Persons_Record_By_Search_Term_Ejud_OFF()
         {
-            _featureToggles.Setup(toggle => toggle.EJudFeature()).Returns(true);
+            _featureToggles.Setup(toggle => toggle.EJudFeature()).Returns(false);
             _handler = new GetPersonBySearchTermQueryHandler(_context, _featureToggles.Object);
             var persons = await _handler.Handle(new GetPersonBySearchTermQuery("luff"));
 

--- a/BookingsApi/BookingsApi.UnitTests/DAL/Services/FeatureFlagServiceTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/DAL/Services/FeatureFlagServiceTests.cs
@@ -1,9 +1,11 @@
 ﻿using Autofac.Extras.Moq;
 using BookingsApi.Common.Exceptions;
+using BookingsApi.Common.Services;
 using BookingsApi.Contract.Configuration;
 using BookingsApi.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
+using Moq;
 using NUnit.Framework;
 
 namespace BookingsApi.UnitTests.DAL.Services
@@ -17,6 +19,7 @@ namespace BookingsApi.UnitTests.DAL.Services
         public void SetUp()
         {
             _mocker = AutoMock.GetLoose();
+            
         }
 
         [Test]
@@ -50,9 +53,10 @@ namespace BookingsApi.UnitTests.DAL.Services
         [Test]
         public void GetFeatureFlag_Should_Return_True_for_EJud_Feature()
         {
+            _mocker.Mock<IFeatureToggles>().Setup(opt => opt.EJudFeature()).Returns(true);
             _mocker.Mock<IOptions<FeatureFlagConfiguration>>().Setup(opt => opt.Value).Returns(new FeatureFlagConfiguration()
             {
-                EJudFeature = true
+                StaffMemberFeature = false
             });
             _service = _mocker.Create<FeatureFlagService>();
 
@@ -64,14 +68,15 @@ namespace BookingsApi.UnitTests.DAL.Services
         [Test]
         public void GetFeatureFlag_Should_Return_False_for_EJud_Feature()
         {
+            _mocker.Mock<IFeatureToggles>().Setup(opt => opt.EJudFeature()).Returns(false);
             _mocker.Mock<IOptions<FeatureFlagConfiguration>>().Setup(opt => opt.Value).Returns(new FeatureFlagConfiguration()
             {
-                EJudFeature = false
+                StaffMemberFeature = false
             });
             _service = _mocker.Create<FeatureFlagService>();
-
+            
             var featureFlag = _service.GetFeatureFlag(nameof(FeatureFlags.EJudFeature));
-
+        
             featureFlag.Should().BeFalse();
         }
 

--- a/BookingsApi/BookingsApi.UnitTests/DAL/Services/FeatureFlagServiceTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/DAL/Services/FeatureFlagServiceTests.cs
@@ -54,10 +54,6 @@ namespace BookingsApi.UnitTests.DAL.Services
         public void GetFeatureFlag_Should_Return_True_for_EJud_Feature()
         {
             _mocker.Mock<IFeatureToggles>().Setup(opt => opt.EJudFeature()).Returns(true);
-            _mocker.Mock<IOptions<FeatureFlagConfiguration>>().Setup(opt => opt.Value).Returns(new FeatureFlagConfiguration()
-            {
-                StaffMemberFeature = false
-            });
             _service = _mocker.Create<FeatureFlagService>();
 
             var featureFlag = _service.GetFeatureFlag(nameof(FeatureFlags.EJudFeature));
@@ -69,10 +65,7 @@ namespace BookingsApi.UnitTests.DAL.Services
         public void GetFeatureFlag_Should_Return_False_for_EJud_Feature()
         {
             _mocker.Mock<IFeatureToggles>().Setup(opt => opt.EJudFeature()).Returns(false);
-            _mocker.Mock<IOptions<FeatureFlagConfiguration>>().Setup(opt => opt.Value).Returns(new FeatureFlagConfiguration()
-            {
-                StaffMemberFeature = false
-            });
+            
             _service = _mocker.Create<FeatureFlagService>();
             
             var featureFlag = _service.GetFeatureFlag(nameof(FeatureFlags.EJudFeature));

--- a/BookingsApi/BookingsApi/Services/FeatureFlagService.cs
+++ b/BookingsApi/BookingsApi/Services/FeatureFlagService.cs
@@ -1,4 +1,5 @@
 ﻿using BookingsApi.Common.Exceptions;
+using BookingsApi.Common.Services;
 using BookingsApi.Contract.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -7,9 +8,11 @@ namespace BookingsApi.Services
     public class FeatureFlagService : IFeatureFlagService
     {
         private readonly FeatureFlagConfiguration _featureFlagConfigurationOptions;
-        public FeatureFlagService(IOptions<FeatureFlagConfiguration> featureFlagConfigurationOptions)
+        private readonly IFeatureToggles _featureToggles;
+        public FeatureFlagService(IOptions<FeatureFlagConfiguration> featureFlagConfigurationOptions, IFeatureToggles featureToggles)
         {
             _featureFlagConfigurationOptions = featureFlagConfigurationOptions.Value;
+            _featureToggles = featureToggles;
         }
         
         public bool GetFeatureFlag(string featureName)
@@ -17,7 +20,7 @@ namespace BookingsApi.Services
             return featureName switch
             {
                 nameof(FeatureFlags.StaffMemberFeature) => _featureFlagConfigurationOptions.StaffMemberFeature,
-                nameof(FeatureFlags.EJudFeature) => _featureFlagConfigurationOptions.EJudFeature,
+                nameof(FeatureFlags.EJudFeature) => _featureToggles.EJudFeature(),
                 _ => throw new FeatureFlagNotFoundException(featureName)
             };
         }

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -172,8 +172,6 @@ extends:
           # Feature Flags
           - name: FeatureFlags:StaffMemberFeature
             value: $(StaffMemberFeature)
-          - name: FeatureFlags:EJudFeature
-            value: $(EJudFeature)
 
         acceptanceTestSettings:
           # AzureAd

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,8 +98,6 @@ parameters:
       # Feature Flags
       - name: FeatureFlags:StaffMemberFeature
         value: $(StaffMemberFeature)
-      - name: FeatureFlags:EJudFeature
-        value: $(EJudFeature)
   
 variables:
   - group: vh-domains-and-urls


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/VIH-9417

Toggles eJud feature moved to Launch Darkly:
Updated the pipelines so they no longer pass in the eJud setting
Updated acceptance tests
