### PR TITLE
VIH-9397 Populate unmapped properties for get unallocated hearings

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
+++ b/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
@@ -210,11 +210,14 @@ namespace BookingsApi.DAL.Services
         {
             var startDate = DateTime.UtcNow;  
 
-            var hearings =  _context.VideoHearings.Where(x =>
-                (x.Status == Domain.Enumerations.BookingStatus.Created || x.Status == Domain.Enumerations.BookingStatus.Booked)
-                && x.Status != Domain.Enumerations.BookingStatus.Cancelled
-                && x.ScheduledDateTime >= startDate
-                && x.CaseTypeId != 3); // Generic Case Type
+            var hearings =  _context.VideoHearings
+                .Include(h => h.CaseType)
+                .Include(h => h.HearingType)
+                .Where(x =>
+                    (x.Status == Domain.Enumerations.BookingStatus.Created || x.Status == Domain.Enumerations.BookingStatus.Booked)
+                    && x.Status != Domain.Enumerations.BookingStatus.Cancelled
+                    && x.ScheduledDateTime >= startDate
+                    && x.CaseTypeId != 3); // Generic Case Type
 
             var unAllocatedHearings =   
                 hearings.Where(x => 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9397


### Change description ###
Some of the properties returned by the Get Unallocated Hearings query are not populated, this causes an error when the API tries to map to a DTO.

Fix by Adding `.Include` to populate these properties


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
