### PR TITLE
VIH-9394 Update user availability logic

### DIFF
--- a/BookingsApi/BookingsApi.Domain/JusticeUser.cs
+++ b/BookingsApi/BookingsApi.Domain/JusticeUser.cs
@@ -45,6 +45,16 @@ namespace BookingsApi.Domain
             var workHourStartTime = workHours.StartTime;
             var workHourEndTime = workHours.EndTime;
 
+            if (workHourStartTime < startDate.TimeOfDay && workHourEndTime < startDate.TimeOfDay)
+            {
+                return false;
+            }
+            
+            if (workHourStartTime > endDate.TimeOfDay && workHourEndTime > endDate.TimeOfDay)
+            {
+                return false;
+            }
+            
             if (!((workHourStartTime <= startDate.TimeOfDay || configuration.AllowHearingToStartBeforeWorkStartTime) && 
                   (workHourEndTime >= endDate.TimeOfDay || configuration.AllowHearingToEndAfterWorkEndTime)))
             {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9394


### Change description ###
Consider a user to be unavailable for allocation if their work hours are outside the hearing times (ie they start and finish before the hearing starts, or start and finish after the hearing ends).

Adds test to ensure that this applies regardless of the allocation settings (allowing hearing to start before work start time = true or false, allow hearing to end after work end time = true or false).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
