### PR TITLE
VIH-9607 Get booking status endpoint

### DIFF
--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -534,7 +534,7 @@ namespace BookingsApi.Client
         /// <param name="hearingId">Id for a hearing</param>
         /// <returns>Hearing shell</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId);
+        System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -543,7 +543,7 @@ namespace BookingsApi.Client
         /// <param name="hearingId">Id for a hearing</param>
         /// <returns>Hearing shell</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Get all hearing venues available for booking
@@ -4077,7 +4077,7 @@ namespace BookingsApi.Client
         /// <param name="hearingId">Id for a hearing</param>
         /// <returns>Hearing shell</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId)
+        public virtual System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId)
         {
             return GetBookingStatusByIdAsync(hearingId, System.Threading.CancellationToken.None);
         }
@@ -4089,7 +4089,7 @@ namespace BookingsApi.Client
         /// <param name="hearingId">Id for a hearing</param>
         /// <returns>Hearing shell</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken)
         {
             if (hearingId == null)
                 throw new System.ArgumentNullException("hearingId");
@@ -4130,7 +4130,7 @@ namespace BookingsApi.Client
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<HearingDetailsResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);

--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -529,6 +529,23 @@ namespace BookingsApi.Client
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<HearingDetailsResponse>> GetUnallocatedHearingsAsync(System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
+        /// Get hearing shell for a given hearing id
+        /// </summary>
+        /// <param name="hearingId">Id for a hearing</param>
+        /// <returns>Hearing shell</returns>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get hearing shell for a given hearing id
+        /// </summary>
+        /// <param name="hearingId">Id for a hearing</param>
+        /// <returns>Hearing shell</returns>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
         /// Get all hearing venues available for booking
         /// </summary>
         /// <returns>List of hearing venues</returns>
@@ -4023,6 +4040,112 @@ namespace BookingsApi.Client
                                 throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new BookingsApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Get hearing shell for a given hearing id
+        /// </summary>
+        /// <param name="hearingId">Id for a hearing</param>
+        /// <returns>Hearing shell</returns>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId)
+        {
+            return GetBookingStatusByIdAsync(hearingId, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get hearing shell for a given hearing id
+        /// </summary>
+        /// <param name="hearingId">Id for a hearing</param>
+        /// <returns>Hearing shell</returns>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<HearingDetailsResponse> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken)
+        {
+            if (hearingId == null)
+                throw new System.ArgumentNullException("hearingId");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/hearings/{hearingId}/status");
+            urlBuilder_.Replace("{hearingId}", System.Uri.EscapeDataString(ConvertToString(hearingId, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<HearingDetailsResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 404)

--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -9,6 +9,7 @@ using BookingsApi.Contract.Queries;
 using BookingsApi.Contract.Requests;
 using BookingsApi.Contract.Responses;
 using BookingsApi.Contract.Configuration;
+using BookingsApi.Contract.Enums;
 
 #pragma warning disable 108 // Disable "CS0108 '{derivedDto}.ToJson()' hides inherited member '{dtoBase}.ToJson()'. Use the new keyword if hiding was intended."
 #pragma warning disable 114 // Disable "CS0114 '{derivedDto}.RaisePropertyChanged(String)' hides inherited member 'dtoBase.RaisePropertyChanged(String)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword."

--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -529,21 +529,21 @@ namespace BookingsApi.Client
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<HearingDetailsResponse>> GetUnallocatedHearingsAsync(System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
-        /// Get hearing shell for a given hearing id
+        /// Get booking status for a given hearing id
         /// </summary>
         /// <param name="hearingId">Id for a hearing</param>
-        /// <returns>Hearing shell</returns>
+        /// <returns>Booking status</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId);
+        System.Threading.Tasks.Task<BookingStatus> GetBookingStatusByIdAsync(System.Guid hearingId);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get hearing shell for a given hearing id
+        /// Get booking status for a given hearing id
         /// </summary>
         /// <param name="hearingId">Id for a hearing</param>
-        /// <returns>Hearing shell</returns>
+        /// <returns>Booking status</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<BookingStatus> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Get all hearing venues available for booking
@@ -4072,24 +4072,24 @@ namespace BookingsApi.Client
         }
 
         /// <summary>
-        /// Get hearing shell for a given hearing id
+        /// Get booking status for a given hearing id
         /// </summary>
         /// <param name="hearingId">Id for a hearing</param>
-        /// <returns>Hearing shell</returns>
+        /// <returns>Booking status</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId)
+        public virtual System.Threading.Tasks.Task<BookingStatus> GetBookingStatusByIdAsync(System.Guid hearingId)
         {
             return GetBookingStatusByIdAsync(hearingId, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get hearing shell for a given hearing id
+        /// Get booking status for a given hearing id
         /// </summary>
         /// <param name="hearingId">Id for a hearing</param>
-        /// <returns>Hearing shell</returns>
+        /// <returns>Booking status</returns>
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<string> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<BookingStatus> GetBookingStatusByIdAsync(System.Guid hearingId, System.Threading.CancellationToken cancellationToken)
         {
             if (hearingId == null)
                 throw new System.ArgumentNullException("hearingId");
@@ -4130,7 +4130,7 @@ namespace BookingsApi.Client
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<BookingStatus>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);

--- a/BookingsApi/BookingsApi.Contract/Enums/BookingStatus.cs
+++ b/BookingsApi/BookingsApi.Contract/Enums/BookingStatus.cs
@@ -2,9 +2,21 @@
 {
     public enum BookingStatus
     {
+        /// <summary>
+        /// Hearing booked
+        /// </summary>
         Booked = 1,
+        /// <summary>
+        /// Conference created
+        /// </summary>
         Created = 2,
+        /// <summary>
+        /// Cancelled
+        /// </summary>
         Cancelled = 3,
+        /// <summary>
+        /// Failed
+        /// </summary>
         Failed = 4
     }
 }

--- a/BookingsApi/BookingsApi.Contract/Requests/Enums/UpdateBookingStatus.cs
+++ b/BookingsApi/BookingsApi.Contract/Requests/Enums/UpdateBookingStatus.cs
@@ -5,8 +5,9 @@
     /// </summary>
     public enum UpdateBookingStatus
     {
-        Created = 1,
-        Cancelled = 2,
-        Failed = 3
+        Booked = 1,
+        Created = 2,
+        Cancelled = 3,
+        Failed = 4
     }
 }

--- a/BookingsApi/BookingsApi.Contract/Requests/Enums/UpdateBookingStatus.cs
+++ b/BookingsApi/BookingsApi.Contract/Requests/Enums/UpdateBookingStatus.cs
@@ -5,9 +5,21 @@
     /// </summary>
     public enum UpdateBookingStatus
     {
+        /// <summary>
+        /// Hearing booked
+        /// </summary>
         Booked = 1,
+        /// <summary>
+        /// Conference created
+        /// </summary>
         Created = 2,
+        /// <summary>
+        /// Cancelled
+        /// </summary>
         Cancelled = 3,
+        /// <summary>
+        /// Failed
+        /// </summary>
         Failed = 4
     }
 }

--- a/BookingsApi/BookingsApi.DAL/Queries/GetHearingShellByIdQuery.cs
+++ b/BookingsApi/BookingsApi.DAL/Queries/GetHearingShellByIdQuery.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using BookingsApi.Domain;
+using BookingsApi.DAL.Queries.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookingsApi.DAL.Queries
+{
+    public class GetHearingShellByIdQuery : IQuery
+    {
+        public Guid HearingId { get; set; }
+
+        public GetHearingShellByIdQuery(Guid hearingId)
+        {
+            HearingId = hearingId;
+        }
+    }
+
+    public class GetHearingShellByIdQueryHandler : IQueryHandler<GetHearingShellByIdQuery, VideoHearing>
+    {
+        private readonly BookingsDbContext _context;
+
+        public GetHearingShellByIdQueryHandler(BookingsDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<VideoHearing> Handle(GetHearingShellByIdQuery query)
+        {
+            return await _context.VideoHearings
+                .AsNoTracking()
+                .SingleOrDefaultAsync(x => x.Id == query.HearingId);
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetHearingShellByIdQueryHandlerDatabaseTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetHearingShellByIdQueryHandlerDatabaseTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using System.Threading.Tasks;
+using BookingsApi.DAL;
+using BookingsApi.DAL.Queries;
+using BookingsApi.Domain.Participants;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BookingsApi.IntegrationTests.Database.Queries
+{
+    public class GetHearingShellByIdQueryHandlerDatabaseTests : DatabaseTestsBase
+    {
+        private GetHearingShellByIdQueryHandler _handler;
+
+        [SetUp]
+        public void Setup()
+        {
+            var context = new BookingsDbContext(BookingsDbContextOptions);
+            _handler = new GetHearingShellByIdQueryHandler(context);
+        }
+
+        [Test]
+        public async Task Should_get_hearing_shell_by_id()
+        {
+            var seededHearing = await Hooks.SeedVideoHearing(false, Domain.Enumerations.BookingStatus.Created, false);
+            TestContext.WriteLine($"New seeded video hearing id: {seededHearing.Id}");
+            var hearing = await _handler.Handle(new GetHearingShellByIdQuery(seededHearing.Id));
+
+            hearing.Should().NotBeNull();
+            hearing.OtherInformation.Should().NotBeEmpty();
+            hearing.CreatedBy.Should().NotBeNullOrEmpty();
+            hearing.Status.Should().Be(Domain.Enumerations.BookingStatus.Created);
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Features/Hearings.feature
+++ b/BookingsApi/BookingsApi.IntegrationTests/Features/Hearings.feature
@@ -194,3 +194,9 @@ Feature: Hearings
     When I send the request to the endpoint
     Then the response should have the status NoContent and success status True
     And hearing status should be Failed
+
+  Scenario: Get booking status for a given hearing
+    Given I have a get booking status for a given request with a valid hearing id
+    When I send the request to the endpoint
+    Then the response should have the status OK and success status True
+    And booking status should be retrieved

--- a/BookingsApi/BookingsApi.IntegrationTests/Steps/HearingsSteps.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Steps/HearingsSteps.cs
@@ -62,6 +62,17 @@ namespace BookingsApi.IntegrationTests.Steps
             Context.HttpMethod = HttpMethod.Get;
         }
 
+        [Given(@"I have a get booking status for a given request with a valid hearing id")]
+        public async Task GivenIHaveAGetBookingStatusForGivenHearingRequest()
+        {
+            var seededHearing = await Context.TestDataManager.SeedVideoHearing();
+            TestContext.WriteLine($"New seeded video hearing id: {seededHearing.Id}");
+            _hearingId = seededHearing.Id;
+            Context.TestData.NewHearingId = seededHearing.Id;
+            Context.Uri = GetHearingShellById(_hearingId);
+            Context.HttpMethod = HttpMethod.Get;
+        }
+
         [Given(@"I have an hearing older than (.*) months")]
         public async Task GivenIHaveAnHearingOlderThanMonths(int p0)
         {
@@ -411,6 +422,13 @@ namespace BookingsApi.IntegrationTests.Steps
         public void ThenHearingDetailsShouldBeUnchanged()
         {
             ThenHearingBookingStatusIs(BookingStatus.Booked);
+        }
+
+        [Then(@"booking status should be retrieved")]
+        public void ThenBookingStatusShouldBeRetrieved()
+        {
+            var responseValue = Context.Response.Content.ReadAsStringAsync();
+            responseValue.Result.Should().Contain(BookingStatus.Booked.ToString());
         }
 
         [Then(@"the response should be an empty list")]

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingParticipantsController/AddParticipantsToHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingParticipantsController/AddParticipantsToHearingTests.cs
@@ -30,7 +30,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingParticipantsController
             request = new AddParticipantsToHearingRequest { Participants = participants };
 
         }
-        private List<ParticipantRequest> BuildParticipants(int listSize)
+        private static List<ParticipantRequest> BuildParticipants(int listSize)
         {
             var participants = Builder<ParticipantRequest>.CreateListOfSize(listSize).All()
                .With(x => x.ContactEmail = $"Automation_{Faker.RandomNumber.Next()}@hmcts.net")

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingParticipantsController/AddParticipantsToHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingParticipantsController/AddParticipantsToHearingTests.cs
@@ -137,7 +137,6 @@ namespace BookingsApi.UnitTests.Controllers.HearingParticipantsController
             QueryHandler.Verify(q => q.Handle<GetHearingByIdQuery, VideoHearing>(It.IsAny<GetHearingByIdQuery>()), Times.Exactly(2));
             QueryHandler.Verify(q => q.Handle<GetCaseTypeQuery, CaseType>(It.IsAny<GetCaseTypeQuery>()), Times.Once);
             CommandHandler.Verify(c => c.Handle(It.IsAny<AddParticipantsToVideoHearingCommand>()), Times.Once);
-            CommandHandler.Verify(c => c.Handle(It.IsAny<UpdateHearingStatusCommand>()), Times.Once);
             EventPublisher.Verify(e => e.PublishAsync(It.IsAny<HearingIsReadyForVideoIntegrationEvent>()), Times.Once);
         }
 

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -101,7 +101,6 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
                                                                                         && c.Endpoints[0].Sip == "@WhereAreYou.com")), Times.Once);
 
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<HearingIsReadyForVideoIntegrationEvent>()), Times.Once);
-            CommandHandlerMock.Verify(x => x.Handle(It.IsAny<UpdateHearingStatusCommand>()), Times.Once);
         }
 
         [Test]
@@ -153,7 +152,6 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
 
             CommandHandlerMock.Verify(c => c.Handle(It.Is<CreateVideoHearingCommand>(c => c.Endpoints.Count == 0)), Times.Once);
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<HearingIsReadyForVideoIntegrationEvent>()), Times.Once);
-            CommandHandlerMock.Verify(x => x.Handle(It.IsAny<UpdateHearingStatusCommand>()), Times.Once);
         }
 
         [Test]
@@ -326,7 +324,6 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
                                                                                           && c.Participants.Any(p => p.Person.FirstName == "FirstNameWithSpaces" || p.Person.FirstName == "FirstName WithSpaces"))), Times.Once);
 
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<HearingIsReadyForVideoIntegrationEvent>()), Times.Once);
-            CommandHandlerMock.Verify(x => x.Handle(It.IsAny<UpdateHearingStatusCommand>()), Times.Once);
         }
         
         [TestCase("LastNameWithSpaces ")]
@@ -358,7 +355,6 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
                                                                                           && c.Participants.Any(p => p.Person.LastName == "LastNameWithSpaces" || p.Person.LastName == "LastName WithSpaces"))), Times.Once);
 
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<HearingIsReadyForVideoIntegrationEvent>()), Times.Once);
-            CommandHandlerMock.Verify(x => x.Handle(It.IsAny<UpdateHearingStatusCommand>()), Times.Once);
         }
         
         [TestCase(null)]

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -24,7 +24,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
         private readonly BookNewHearingRequest request = RequestBuilder.Build();
         private VideoHearing _videoHearing;
 
-        private List<CaseRole> CaseRoles => new List<CaseRole>
+        private static List<CaseRole> CaseRoles => new List<CaseRole>
         {
             CreateCaseAndHearingRoles(1, "Applicant",new List<string>{ "Litigant in person", "Representative"}),
             CreateCaseAndHearingRoles(2, "Respondent",new List<string>{ "Litigant in person", "Representative"}),

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -32,7 +32,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
             CreateCaseAndHearingRoles(4, "Judicial Office Holder", new List<string> { "Judicial Office Holder" })
         };
 
-        private CaseRole CreateCaseAndHearingRoles(int caseId, string caseRoleName, List<string> roles)
+        private static CaseRole CreateCaseAndHearingRoles(int caseId, string caseRoleName, List<string> roles)
         {
             var hearingRoles = new List<HearingRole>();
 

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/CloneHearingTests.cs
@@ -71,8 +71,6 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
 
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<HearingIsReadyForVideoIntegrationEvent>()), Times.Exactly(request.Dates.Count));
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<MultiDayHearingIntegrationEvent>()), Times.Once);
-
-            CommandHandlerMock.Verify(x => x.Handle(It.IsAny<UpdateHearingStatusCommand>()), Times.Exactly(request.Dates.Count));
         }
 
         [Test]

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/GetBookingStatusByIdTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/GetBookingStatusByIdTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using BookingsApi.Contract.Responses;
+using BookingsApi.Domain;
+using BookingsApi.DAL.Queries;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Testing.Common.Assertions;
+using BookingsApi.Contract.Enums;
+
+namespace BookingsApi.UnitTests.Controllers.HearingsController
+{
+    public class GetBookingStatusByIdTests : HearingsControllerTests
+    {
+        [Test]
+        public async Task Should_return_booking_status_for_given_hearingid()
+        {
+            var hearingId = Guid.NewGuid();
+            var hearing = GetHearing("123");
+
+            QueryHandlerMock
+             .Setup(x => x.Handle<GetHearingShellByIdQuery, VideoHearing>(It.IsAny<GetHearingShellByIdQuery>()))
+             .ReturnsAsync(hearing);
+
+            var result = await Controller.GetBookingStatusById(hearingId);
+
+            result.Should().NotBeNull();
+            var objectResult = (OkObjectResult)result;
+            objectResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            objectResult.Value.Should().BeEquivalentTo(BookingStatus.Booked);
+            QueryHandlerMock.Verify(x => x.Handle<GetHearingShellByIdQuery, VideoHearing>(It.IsAny<GetHearingShellByIdQuery>()), Times.Once);
+        }
+
+        [Test]
+        public async Task Should_return_badrequest_for_given_invalid_hearingid()
+        {
+            var hearingId = Guid.Empty;
+
+            var result = await Controller.GetBookingStatusById(hearingId);
+
+            result.Should().NotBeNull();
+            var objectResult = (BadRequestObjectResult)result;
+            objectResult.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
+            ((SerializableError)objectResult.Value).ContainsKeyAndErrorMessage(nameof(hearingId), $"Please provide a valid {nameof(hearingId)}");
+            QueryHandlerMock.Verify(x => x.Handle<GetHearingShellByIdQuery, VideoHearing>(It.IsAny<GetHearingShellByIdQuery>()), Times.Never);
+        }
+
+        [Test]
+        public async Task Should_return_notfound_with_no_video_hearing()
+        {
+            var hearingId = Guid.NewGuid();
+
+            QueryHandlerMock
+             .Setup(x => x.Handle<GetHearingShellByIdQuery, VideoHearing>(It.IsAny<GetHearingShellByIdQuery>()))
+             .ReturnsAsync((VideoHearing)null);
+
+            var result = await Controller.GetBookingStatusById(hearingId);
+
+            result.Should().NotBeNull();
+            var objectResult = (NotFoundResult)result;
+            objectResult.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+            QueryHandlerMock.Verify(x => x.Handle<GetHearingShellByIdQuery, VideoHearing>(It.IsAny<GetHearingShellByIdQuery>()), Times.Once);
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.UnitTests/DAL/Queries/GetHearingShellQueryTest.cs
+++ b/BookingsApi/BookingsApi.UnitTests/DAL/Queries/GetHearingShellQueryTest.cs
@@ -1,0 +1,65 @@
+﻿using BookingsApi.DAL;
+using BookingsApi.DAL.Queries;
+using BookingsApi.Domain;
+using BookingsApi.Domain.RefData;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Testing.Common.Builders.Domain;
+
+namespace BookingsApi.UnitTests.DAL.Queries
+{
+    public class GetHearingShellQueryTest
+    {
+        private BookingsDbContext _context;
+        private VideoHearing _hearing;
+        private GetHearingShellByIdQueryHandler _handler;
+        private readonly string _caseTypeName = "Generic";
+        private readonly string _hearingTypeName = "Automated Test";
+        private readonly string _hearingVenueName = "Birmingham Civil and Family Justice Centre";
+
+        [OneTimeSetUp]
+        public void InitialSetup()
+        {
+            var contextOptions = new DbContextOptionsBuilder<BookingsDbContext>()
+                .UseInMemoryDatabase("VhBookingsInMemory").Options;
+            _context = new BookingsDbContext(contextOptions);
+            var refDataBuilder = new RefDataBuilder();
+            var venue = refDataBuilder.HearingVenues.First(x => x.Name == _hearingVenueName);
+            var caseType = new CaseType(1, _caseTypeName);
+            var hearingType = Builder<HearingType>.CreateNew().WithFactory(() => new HearingType(_hearingTypeName)).Build();
+            var scheduledDateTime = DateTime.Today.AddDays(1).AddHours(11).AddMinutes(45);
+            var duration = 80;
+            var hearingRoomName = "Roome03";
+            var otherInformation = "OtherInformation03";
+            var createdBy = "User03";
+            const bool questionnaireNotRequired = false;
+            const bool audioRecordingRequired = true;
+            var cancelReason = "Online abandonment (incomplete registration)";
+            _hearing = new VideoHearing(caseType, hearingType, scheduledDateTime, duration, venue, hearingRoomName,
+                        otherInformation, createdBy, questionnaireNotRequired, audioRecordingRequired, cancelReason);
+            _context.VideoHearings.Add(_hearing);
+            _context.SaveChangesAsync();
+        }
+
+        [OneTimeTearDown]
+        public void FinalCleanUp()
+        {
+            _context.Database.EnsureDeleted();
+        }
+
+        [Test]
+        public async Task Should_create_handler()
+        { 
+            _handler = new GetHearingShellByIdQueryHandler(_context);
+            var hearing = await _handler.Handle(new GetHearingShellByIdQuery(_hearing.Id));
+            hearing.Should().NotBeNull();
+        }
+    }
+}
+
+

--- a/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
@@ -573,13 +573,15 @@ namespace BookingsApi.Controllers
                     {
                         var primaryLinkedParticipant = hearing.GetParticipants().SingleOrDefault(x => x.Person.ContactEmail == linkedParticipant.ParticipantContactEmail);
                         var secondaryLinkedParticipant = hearing.GetParticipants().SingleOrDefault(x => x.Person.ContactEmail == linkedParticipant.LinkedParticipantContactEmail);
-                
-                        eventLinkedParticipants.Add(new Infrastructure.Services.Dtos.LinkedParticipantDto
+                        if (primaryLinkedParticipant != null && secondaryLinkedParticipant != null)
                         {
-                            LinkedId = secondaryLinkedParticipant.Id,
-                            ParticipantId = primaryLinkedParticipant.Id,
-                            Type = linkedParticipant.Type
-                        });
+                            eventLinkedParticipants.Add(new Infrastructure.Services.Dtos.LinkedParticipantDto
+                            {
+                                LinkedId = secondaryLinkedParticipant.Id,
+                                ParticipantId = primaryLinkedParticipant.Id,
+                                Type = linkedParticipant.Type
+                            });
+                        }
                     }
                 
                     var hearingParticipantsUpdatedIntegrationEvent = new HearingParticipantsUpdatedIntegrationEvent(hearing, eventExistingParticipants, eventNewParticipants, removedParticipantIds, eventLinkedParticipants);
@@ -616,7 +618,7 @@ namespace BookingsApi.Controllers
             
         }
 
-        private List<ParticipantResponse> CreateParticipantResponseList(IEnumerable<Participant> participants)
+        private static List<ParticipantResponse> CreateParticipantResponseList(IEnumerable<Participant> participants)
         {
             if (participants.Any())
             {

--- a/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingParticipantsController.cs
@@ -537,7 +537,6 @@ namespace BookingsApi.Controllers
                 }
                 else if (participants.Any(x => x.HearingRole.UserRole.Name == "Judge"))
                 {
-                    await UpdateHearingStatusAsync(hearing.Id, BookingStatus.Created, "System", string.Empty);
                     await _eventPublisher.PublishAsync(new HearingIsReadyForVideoIntegrationEvent(hearing, participants));
                 }
                 else

--- a/BookingsApi/BookingsApi/Controllers/HearingsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingsController.cs
@@ -806,7 +806,7 @@ namespace BookingsApi.Controllers
         /// <returns>Hearing shell</returns>
         [HttpGet("{hearingId}/status", Name = "GetBookingStatusById")]
         [OpenApiOperation("GetBookingStatusById")]
-        [ProducesResponseType(typeof(HearingDetailsResponse), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
         public async Task<IActionResult> GetBookingStatusById(Guid hearingId)

--- a/BookingsApi/BookingsApi/Controllers/HearingsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingsController.cs
@@ -319,8 +319,6 @@ namespace BookingsApi.Controllers
         {
             if (videoHearing.Participants.Any(x => x.HearingRole.Name == "Judge"))
             {
-                // Confirm the hearing
-                await UpdateHearingStatusAsync(videoHearing.Id, BookingStatus.Created, "System", string.Empty);
                 // The event below handles creatign users, sending the hearing notifications to the participants if the hearing is not a multi day
                 await _eventPublisher.PublishAsync(new HearingIsReadyForVideoIntegrationEvent(videoHearing, videoHearing.Participants));
             }
@@ -800,6 +798,36 @@ namespace BookingsApi.Controllers
             var response = results.Select(hearingMapper.MapHearingToDetailedResponse).ToList();
             return Ok(response);
         }
+
+        /// <summary>
+        /// Get hearing shell for a given hearing id
+        /// </summary>
+        /// <param name="hearingId">Id for a hearing</param>
+        /// <returns>Hearing shell</returns>
+        [HttpGet("{hearingId}/status", Name = "GetBookingStatusById")]
+        [OpenApiOperation("GetBookingStatusById")]
+        [ProducesResponseType(typeof(HearingDetailsResponse), (int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.NotFound)]
+        public async Task<IActionResult> GetBookingStatusById(Guid hearingId)
+        {
+            if (hearingId == Guid.Empty)
+            {
+                ModelState.AddModelError(nameof(hearingId), $"Please provide a valid {nameof(hearingId)}");
+                return BadRequest(ModelState);
+            }
+
+            var query = new GetHearingShellByIdQuery(hearingId);
+            var videoHearing = await _queryHandler.Handle<GetHearingShellByIdQuery, VideoHearing>(query);
+
+            if (videoHearing == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(videoHearing.Status);
+        }
+
 
         private static void SanitiseRequest(BookNewHearingRequest request)
         {

--- a/BookingsApi/BookingsApi/Controllers/HearingsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/HearingsController.cs
@@ -31,6 +31,7 @@ using BookingsApi.Validations;
 using NSwag.Annotations;
 using BookingsApi.DAL.Services;
 using BookingsApi.Services;
+using BookingsApi.Contract.Requests.Enums;
 
 namespace BookingsApi.Controllers
 {
@@ -800,13 +801,13 @@ namespace BookingsApi.Controllers
         }
 
         /// <summary>
-        /// Get hearing shell for a given hearing id
+        /// Get booking status for a given hearing id
         /// </summary>
         /// <param name="hearingId">Id for a hearing</param>
-        /// <returns>Hearing shell</returns>
+        /// <returns>Booking status</returns>
         [HttpGet("{hearingId}/status", Name = "GetBookingStatusById")]
         [OpenApiOperation("GetBookingStatusById")]
-        [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(Contract.Enums.BookingStatus), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
         public async Task<IActionResult> GetBookingStatusById(Guid hearingId)
@@ -825,7 +826,7 @@ namespace BookingsApi.Controllers
                 return NotFound();
             }
 
-            return Ok(videoHearing.Status);
+            return Ok((Contract.Enums.BookingStatus)videoHearing.Status);
         }
 
 

--- a/BookingsApi/BookingsApi/nswag.json
+++ b/BookingsApi/BookingsApi/nswag.json
@@ -93,7 +93,8 @@
         "BookingsApi.Contract.Queries",
         "BookingsApi.Contract.Requests",
         "BookingsApi.Contract.Responses",
-        "BookingsApi.Contract.Configuration"
+        "BookingsApi.Contract.Configuration",
+        "BookingsApi.Contract.Enums"
       ],
       "additionalContractNamespaceUsages": [],
       "generateOptionalParameters": false,

--- a/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
+++ b/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
@@ -23,6 +23,7 @@ namespace Testing.Common.Builders.Api
         {
             private const string ApiRoot = "hearings";
             public static string GetHearingDetailsById(Guid hearingId) => $"{ApiRoot}/{hearingId}";
+            public static string GetHearingShellById(Guid hearingId) => $"{ApiRoot}/{hearingId}/status";
             public static string BookNewHearing => $"{ApiRoot}";
             public static string HearingTypesRelativePath => $"{ApiRoot}/types";
             public static string CloneHearing(Guid hearingId) => $"{ApiRoot}/{hearingId}/clone";


### PR DESCRIPTION
New query to retrieve hearing shell data. New endpoint to retrieve booking status. Removed update booking status to created when the judge is added instead this status will be updated from booking queue subscriber so the admin web can poll this status rather than for the conference

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```
