### PR TITLE
VIH-9367 Delete justice user

### DIFF
--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -675,6 +675,21 @@ namespace BookingsApi.Client
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<JusticeUserResponse>> GetJusticeUserListAsync(string term, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
+        /// Delete a justice user
+        /// </summary>
+        /// <param name="id">The justice user id</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<string> DeleteJusticeUserAsync(System.Guid id);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Delete a justice user
+        /// </summary>
+        /// <param name="id">The justice user id</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<string> DeleteJusticeUserAsync(System.Guid id, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
         /// Get a participants by username
         /// </summary>
         /// <param name="username">The username of the participant</param>
@@ -5490,6 +5505,120 @@ namespace BookingsApi.Client
                                 throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new BookingsApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new BookingsApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Delete a justice user
+        /// </summary>
+        /// <param name="id">The justice user id</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<string> DeleteJusticeUserAsync(System.Guid id)
+        {
+            return DeleteJusticeUserAsync(id, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Delete a justice user
+        /// </summary>
+        /// <param name="id">The justice user id</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<string> DeleteJusticeUserAsync(System.Guid id, System.Threading.CancellationToken cancellationToken)
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/justiceuser/{id}");
+            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("DELETE");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<string>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 204)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<string>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ValidationProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<ValidationProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {

--- a/BookingsApi/BookingsApi.DAL/BookingsDbContext.cs
+++ b/BookingsApi/BookingsApi.DAL/BookingsDbContext.cs
@@ -57,6 +57,9 @@ namespace BookingsApi.DAL
                     }
                 }
             }
+
+            modelBuilder.Entity<JusticeUser>().HasQueryFilter(u => !u.Deleted);
+            modelBuilder.Entity<VhoWorkHours>().HasQueryFilter(wh => !wh.Deleted);
         }
         
         public override int SaveChanges()

--- a/BookingsApi/BookingsApi.DAL/Commands/AddJusticeUserCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/AddJusticeUserCommand.cs
@@ -6,6 +6,7 @@ using BookingsApi.DAL.Exceptions;
 using BookingsApi.Domain;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.RefData;
+using Microsoft.EntityFrameworkCore;
 
 namespace BookingsApi.DAL.Commands
 {
@@ -45,7 +46,7 @@ namespace BookingsApi.DAL.Commands
             var roleName = command.RoleId == (int)UserRoleId.VhTeamLead ? "Video hearings team lead" : "Video hearings officer";
             var role = new UserRole(command.RoleId, roleName);
 
-            if (_context.JusticeUsers.Any(x => x.Username.ToLower() == command.Username.ToLower()))
+            if (_context.JusticeUsers.IgnoreQueryFilters().Any(x => x.Username.ToLower() == command.Username.ToLower()))
             {
                 throw new JusticeUserAlreadyExistsException(command.Username);
             }

--- a/BookingsApi/BookingsApi.DAL/Commands/DeleteJusticeUserCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/DeleteJusticeUserCommand.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BookingsApi.DAL.Commands.Core;
+using BookingsApi.DAL.Exceptions;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookingsApi.DAL.Commands
+{
+    public class DeleteJusticeUserCommand : ICommand
+    {
+        public Guid Id { get; }
+
+        public DeleteJusticeUserCommand(Guid id)
+        {
+            Id = id;
+        }
+    }
+    
+    public class DeleteJusticeUserCommandHandler : ICommandHandler<DeleteJusticeUserCommand>
+    {
+        private readonly BookingsDbContext _context;
+
+        public DeleteJusticeUserCommandHandler(BookingsDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task Handle(DeleteJusticeUserCommand command)
+        {
+            var justiceUser = await _context.JusticeUsers
+                .Include(u => u.VhoWorkHours)
+                .Include(u => u.VhoNonAvailability)
+                .Include(u => u.Allocations).ThenInclude(a => a.Hearing)
+                .FirstOrDefaultAsync(u => u.Id == command.Id);
+
+            if (justiceUser == null)
+            {
+                throw new JusticeUserNotFoundException(command.Id);
+            }
+            
+            justiceUser.Delete();
+      
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Commands/DeleteNonWorkingHoursCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/DeleteNonWorkingHoursCommand.cs
@@ -40,7 +40,7 @@ namespace BookingsApi.DAL.Commands
                 throw new NonWorkingHoursNotFoundException(command.Id);
             }
 
-            hours.Deleted = true;
+            hours.Delete();
             
             _context.Update(hours);
 

--- a/BookingsApi/BookingsApi.DAL/Exceptions/JusticeUserNotFoundException.cs
+++ b/BookingsApi/BookingsApi.DAL/Exceptions/JusticeUserNotFoundException.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace BookingsApi.DAL.Exceptions
+{
+    [Serializable]
+    public class JusticeUserNotFoundException : BookingsDalException
+    {
+        public JusticeUserNotFoundException(Guid id) : base($"Justice user with id {id} not found")
+        {
+        }
+
+        protected JusticeUserNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Migrations/20230223155544_AddDeletedColumnsForJusticeUser.Designer.cs
+++ b/BookingsApi/BookingsApi.DAL/Migrations/20230223155544_AddDeletedColumnsForJusticeUser.Designer.cs
@@ -4,6 +4,7 @@ using BookingsApi.DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookingsApi.DAL.Migrations
 {
     [DbContext(typeof(BookingsDbContext))]
-    partial class BookingsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230223155544_AddDeletedColumnsForJusticeUser")]
+    partial class AddDeletedColumnsForJusticeUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookingsApi/BookingsApi.DAL/Migrations/20230223155544_AddDeletedColumnsForJusticeUser.cs
+++ b/BookingsApi/BookingsApi.DAL/Migrations/20230223155544_AddDeletedColumnsForJusticeUser.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookingsApi.DAL.Migrations
+{
+    public partial class AddDeletedColumnsForJusticeUser : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Deleted",
+                table: "VhoWorkHours",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VhoWorkHours_Deleted",
+                table: "VhoWorkHours",
+                column: "Deleted");
+            
+            migrationBuilder.AddColumn<bool>(
+                name: "Deleted",
+                table: "JusticeUser",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_JusticeUser_Deleted",
+                table: "JusticeUser",
+                column: "Deleted");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Deleted",
+                table: "VhoWorkHours");
+            
+            migrationBuilder.DropIndex(
+                name: "IX_VhoWorkHours_Deleted",
+                table: "VhoWorkHours");
+
+            migrationBuilder.DropColumn(
+                name: "Deleted",
+                table: "JusticeUser");
+            
+            migrationBuilder.DropIndex(
+                name: "IX_JusticeUser_Deleted",
+                table: "JusticeUser");
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.Domain/JusticeUser.cs
+++ b/BookingsApi/BookingsApi.Domain/JusticeUser.cs
@@ -87,7 +87,10 @@ namespace BookingsApi.Domain
         {
             Deleted = true;
 
-            DeleteWorkHours();            
+            foreach (var workHour in VhoWorkHours)
+            {
+                workHour.Delete();
+            }
 
             foreach (var nonAvailability in VhoNonAvailability)
             {
@@ -103,14 +106,6 @@ namespace BookingsApi.Domain
         public void Restore()
         {
             Deleted = false;
-        }
-
-        private void DeleteWorkHours()
-        {
-            foreach (var workHour in VhoWorkHours)
-            {
-                workHour.Deleted = true;
-            }
         }
     }
 }

--- a/BookingsApi/BookingsApi.Domain/JusticeUser.cs
+++ b/BookingsApi/BookingsApi.Domain/JusticeUser.cs
@@ -100,6 +100,11 @@ namespace BookingsApi.Domain
             }
         }
 
+        public void Restore()
+        {
+            Deleted = false;
+        }
+
         private void DeleteWorkHours()
         {
             foreach (var workHour in VhoWorkHours)

--- a/BookingsApi/BookingsApi.Domain/JusticeUser.cs
+++ b/BookingsApi/BookingsApi.Domain/JusticeUser.cs
@@ -33,6 +33,7 @@ namespace BookingsApi.Domain
         public int UserRoleId { get; set; }
         public UserRole UserRole { get; set; }
         public string CreatedBy { get; set; }
+        public bool Deleted { get; private set; }
 
         public virtual IList<VhoNonAvailability> VhoNonAvailability { get; protected set; }
         public virtual IList<VhoWorkHours> VhoWorkHours { get; protected set; }
@@ -80,6 +81,31 @@ namespace BookingsApi.Domain
             
             return (workHourStartTime <= startDate.TimeOfDay || configuration.AllowHearingToStartBeforeWorkStartTime) && 
                    (workHourEndTime >= endDate.TimeOfDay || configuration.AllowHearingToEndAfterWorkEndTime);
+        }
+
+        public void Delete()
+        {
+            Deleted = true;
+
+            DeleteWorkHours();            
+
+            foreach (var nonAvailability in VhoNonAvailability)
+            {
+                nonAvailability.Delete();
+            }
+            
+            foreach (var hearing in Allocations.Select(a => a.Hearing))
+            {
+                hearing.Deallocate();
+            }
+        }
+
+        private void DeleteWorkHours()
+        {
+            foreach (var workHour in VhoWorkHours)
+            {
+                workHour.Deleted = true;
+            }
         }
     }
 }

--- a/BookingsApi/BookingsApi.Domain/VhoNonAvailability.cs
+++ b/BookingsApi/BookingsApi.Domain/VhoNonAvailability.cs
@@ -19,5 +19,10 @@ namespace BookingsApi.Domain
             Id = id;
         }
         public bool Deleted { get; set; }
+
+        public void Delete()
+        {
+            Deleted = true;
+        }
     }
 }

--- a/BookingsApi/BookingsApi.Domain/VhoWorkHours.cs
+++ b/BookingsApi/BookingsApi.Domain/VhoWorkHours.cs
@@ -23,6 +23,11 @@ namespace BookingsApi.Domain
                 return (System.DayOfWeek)DayOfWeekId;
             }
         }
-        public bool Deleted { get; set; }
+        public bool Deleted { get; private set; }
+
+        public void Delete()
+        {
+            Deleted = true;
+        }
     }
 }

--- a/BookingsApi/BookingsApi.Domain/VhoWorkHours.cs
+++ b/BookingsApi/BookingsApi.Domain/VhoWorkHours.cs
@@ -23,5 +23,6 @@ namespace BookingsApi.Domain
                 return (System.DayOfWeek)DayOfWeekId;
             }
         }
+        public bool Deleted { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/JusticeUsers/DeleteJusticeUserTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/JusticeUsers/DeleteJusticeUserTests.cs
@@ -37,6 +37,7 @@ namespace BookingsApi.IntegrationTests.Api.JusticeUsers
 
             await using var db = new BookingsDbContext(BookingsDbContextOptions);
             var foundJusticeUser = await db.JusticeUsers
+                .IgnoreQueryFilters()
                 .Include(u => u.VhoWorkHours)
                 .Include(u => u.VhoNonAvailability)
                 .Include(u => u.Allocations)

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/JusticeUsers/DeleteJusticeUserTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/JusticeUsers/DeleteJusticeUserTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using BookingsApi.DAL;
+using BookingsApi.Domain;
+using BookingsApi.Domain.Enumerations;
+using BookingsApi.IntegrationTests.Helper;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Testing.Common.Builders.Api;
+
+namespace BookingsApi.IntegrationTests.Api.JusticeUsers
+{
+    public class DeleteJusticeUserTests : ApiTest
+    {
+        private const string Username = "api_test_delete_justice_user@test.com";
+
+        [Test]
+        public async Task Should_delete_justice_user()
+        {
+            // Arrange
+            using var client = Application.CreateClient();
+            var hearing = await SeedHearing();
+            var justiceUser = await SeedJusticeUser(hearing.Id);
+
+            // Act
+            var result = await client.DeleteAsync(
+                ApiUriFactory.JusticeUserEndpoints.DeleteJusticeUser(justiceUser.Id));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeTrue();
+            result.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var foundJusticeUser = await db.JusticeUsers
+                .Include(u => u.VhoWorkHours)
+                .Include(u => u.VhoNonAvailability)
+                .Include(u => u.Allocations)
+                .FirstOrDefaultAsync(x => x.Id == justiceUser.Id);
+            foundJusticeUser.Should().NotBeNull();
+            foundJusticeUser.Deleted.Should().BeTrue();
+            foundJusticeUser.VhoWorkHours.Count.Should().Be(justiceUser.VhoWorkHours.Count);
+            foreach (var workHour in foundJusticeUser.VhoWorkHours)
+            {
+                workHour.Deleted.Should().BeTrue();
+            }
+            foundJusticeUser.VhoNonAvailability.Count.Should().Be(justiceUser.VhoNonAvailability.Count);
+            foreach (var nonAvailability in foundJusticeUser.VhoNonAvailability)
+            {
+                nonAvailability.Deleted.Should().BeTrue();
+            }
+            foundJusticeUser.Allocations.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task Should_return_not_found_when_justice_user_does_not_exist()
+        {
+            // Arrange
+            using var client = Application.CreateClient();
+            var id = Guid.NewGuid();
+
+            // Act
+            var result = await client.DeleteAsync(
+                ApiUriFactory.JusticeUserEndpoints.DeleteJusticeUser(id));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeFalse();
+            result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+            var responseBody = await ApiClientResponse.GetResponses<string>(result.Content);
+            responseBody.Should().Be($"Justice user with id {id} not found");
+        }
+
+        [Test]
+        public async Task Should_return_bad_request_when_invalid_id_specified()
+        {
+            // Arrange
+            using var client = Application.CreateClient();
+            var id = Guid.Empty;
+            
+            // Act
+            var result = await client.DeleteAsync(
+                ApiUriFactory.JusticeUserEndpoints.DeleteJusticeUser(id));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeFalse();
+            result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var responseBody = await ApiClientResponse.GetResponses<ValidationProblemDetails>(result.Content);
+            var errors = responseBody.Errors["id"];
+            errors[0].Should().Be($"Please provide a valid {nameof(id)}");
+        }
+        
+        [TearDown]
+        public async Task TearDown()
+        {
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var justiceUser = db.JusticeUsers.FirstOrDefault(x => x.Username == Username);
+            if (justiceUser != null)
+            {
+                db.Remove(justiceUser);
+                await db.SaveChangesAsync();
+            }
+        }
+
+        private async Task<VideoHearing> SeedHearing() => await Hooks.SeedVideoHearing();
+
+        private async Task<JusticeUser> SeedJusticeUser(Guid allocatedHearingId)
+        {
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            
+            // Justice user
+            var justiceUser = db.JusticeUsers.Add(new JusticeUser
+            {
+                ContactEmail = Username,
+                Username = Username,
+                UserRoleId = (int)UserRoleId.Vho,
+                CreatedBy = "integration.test@test.com",
+                CreatedDate = DateTime.UtcNow,
+                FirstName = "ApiTest",
+                Lastname = "User",
+            });
+            
+            // Work hours
+            for (var i = 1; i <= 7; i++)
+            {
+                justiceUser.Entity.VhoWorkHours.Add(new VhoWorkHours
+                {
+                    DayOfWeekId = i, 
+                    StartTime = new TimeSpan(8, 0, 0), 
+                    EndTime = new TimeSpan(17, 0, 0)
+                });
+            }
+            
+            // Non availabilities
+            justiceUser.Entity.VhoNonAvailability.Add(new VhoNonAvailability
+            {
+                StartTime = new DateTime(2022, 1, 1, 8, 0, 0),
+                EndTime = new DateTime(2022, 1, 1, 17, 0, 0)
+            });
+            justiceUser.Entity.VhoNonAvailability.Add(new VhoNonAvailability
+            {
+                StartTime = new DateTime(2022, 1, 2, 8, 0, 0),
+                EndTime = new DateTime(2022, 1, 2, 17, 0, 0)
+            });
+            
+            // Allocations
+            db.Allocations.Add(new Allocation
+            {
+                HearingId = allocatedHearingId,
+                JusticeUserId = justiceUser.Entity.Id
+            });
+
+            await db.SaveChangesAsync();
+
+            return justiceUser.Entity;
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/DeleteJusticeUserCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/DeleteJusticeUserCommandTests.cs
@@ -59,7 +59,7 @@ namespace BookingsApi.IntegrationTests.Database.Commands
         }
         
         [Test]
-        public async Task should_throw_an_exception_when_justice_user_does_not_exist()
+        public void should_throw_an_exception_when_justice_user_does_not_exist()
         {
             // Arrange
             var id = Guid.NewGuid();

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/DeleteJusticeUserCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/DeleteJusticeUserCommandTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BookingsApi.DAL;
+using BookingsApi.DAL.Commands;
+using BookingsApi.DAL.Exceptions;
+using BookingsApi.Domain;
+using BookingsApi.Domain.Enumerations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace BookingsApi.IntegrationTests.Database.Commands
+{
+    public class DeleteJusticeUserCommandTests : DatabaseTestsBase
+    {
+        private DeleteJusticeUserCommandHandler _commandHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            var context = new BookingsDbContext(BookingsDbContextOptions);
+            _commandHandler = new DeleteJusticeUserCommandHandler(context);
+        }
+
+        [Test]
+        public async Task should_delete_justice_user()
+        {
+            // Arrange
+            var hearing = await SeedHearing();
+            var justiceUserToDelete = await SeedJusticeUser("should_delete_justice_user@testdb.com", hearing.Id);
+
+            var command = new DeleteJusticeUserCommand(justiceUserToDelete.Id);
+            
+            // Act
+            await _commandHandler.Handle(command);
+            
+            // Assert
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var justiceUser = await db.JusticeUsers
+                .IgnoreQueryFilters()
+                .Include(u => u.VhoWorkHours)
+                .Include(u => u.VhoNonAvailability)
+                .Include(u => u.Allocations)
+                .FirstOrDefaultAsync(x => x.Id == justiceUserToDelete.Id);
+            justiceUser.Should().NotBeNull();
+            justiceUser.Deleted.Should().BeTrue();
+            justiceUser.VhoWorkHours.Count.Should().Be(justiceUserToDelete.VhoWorkHours.Count);
+            foreach (var workHour in justiceUser.VhoWorkHours)
+            {
+                workHour.Deleted.Should().BeTrue();
+            }
+            justiceUser.VhoNonAvailability.Count.Should().Be(justiceUserToDelete.VhoNonAvailability.Count);
+            foreach (var nonAvailability in justiceUser.VhoNonAvailability)
+            {
+                nonAvailability.Deleted.Should().BeTrue();
+            }
+            justiceUser.Allocations.Should().BeEmpty();
+        }
+        
+        [Test]
+        public async Task should_throw_an_exception_when_justice_user_does_not_exist()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            
+            var command = new DeleteJusticeUserCommand(id);
+
+            // Act & Assert
+            Assert.ThrowsAsync<JusticeUserNotFoundException>(async () =>
+            {
+                await _commandHandler.Handle(command);
+            }).Message.Should().Be($"Justice user with id {id} not found");
+        }
+
+        [TearDown]
+        public new async Task TearDown()
+        {
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            db.JusticeUsers.RemoveRange(db.JusticeUsers.IgnoreQueryFilters().Where(ju => ju.CreatedBy == "db@test.com"));
+            await db.SaveChangesAsync();
+        }
+        
+        private async Task<VideoHearing> SeedHearing() => await Hooks.SeedVideoHearing();
+
+        private async Task<JusticeUser> SeedJusticeUser(string username, Guid allocatedHearingId)
+        {
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            
+            // Justice user
+            var justiceUser = db.JusticeUsers.Add(new JusticeUser
+            {
+                ContactEmail = username,
+                Username = username,
+                UserRoleId = (int)UserRoleId.Vho,
+                CreatedBy = "db@test.com",
+                CreatedDate = DateTime.UtcNow,
+                FirstName = "Test",
+                Lastname = "User",
+            });
+            
+            // Work hours
+            for (var i = 1; i <= 7; i++)
+            {
+                justiceUser.Entity.VhoWorkHours.Add(new VhoWorkHours
+                {
+                    DayOfWeekId = i, 
+                    StartTime = new TimeSpan(8, 0, 0), 
+                    EndTime = new TimeSpan(17, 0, 0)
+                });
+            }
+            
+            // Non availabilities
+            justiceUser.Entity.VhoNonAvailability.Add(new VhoNonAvailability
+            {
+                StartTime = new DateTime(2022, 1, 1, 8, 0, 0),
+                EndTime = new DateTime(2022, 1, 1, 17, 0, 0)
+            });
+            justiceUser.Entity.VhoNonAvailability.Add(new VhoNonAvailability
+            {
+                StartTime = new DateTime(2022, 1, 2, 8, 0, 0),
+                EndTime = new DateTime(2022, 1, 2, 17, 0, 0)
+            });
+            
+            // Allocations
+            db.Allocations.Add(new Allocation
+            {
+                HearingId = allocatedHearingId,
+                JusticeUserId = justiceUser.Entity.Id
+            });
+
+            await db.SaveChangesAsync();
+
+            return justiceUser.Entity;
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
@@ -479,7 +479,7 @@ namespace BookingsApi.IntegrationTests.Helper
                 try
                 {
                     await using var db = new BookingsDbContext(_dbContextOptions);
-                    var justiceUser = await db.JusticeUsers.SingleOrDefaultAsync(x => x.Id == id);
+                    var justiceUser = await db.JusticeUsers.IgnoreQueryFilters().SingleOrDefaultAsync(x => x.Id == id);
                     if (justiceUser != null)
                     {
                         db.JusticeUsers.Remove(justiceUser);

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/JusticeUserControllerTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/JusticeUserControllerTests.cs
@@ -93,7 +93,7 @@ namespace BookingsApi.UnitTests.Controllers
             Assert.IsInstanceOf<OkObjectResult>(response);
             Assert.AreEqual(expectedJusticeUserReponseJson, actualJusticeUserReponseJson);
         }
-        
+
         [Test]
         public async Task GetJusticeUserList_Filter_By_Term_ReturnsList()
         {

--- a/BookingsApi/BookingsApi/Controllers/JusticeUserController.cs
+++ b/BookingsApi/BookingsApi/Controllers/JusticeUserController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BookingsApi.Contract.Responses;
@@ -9,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using NSwag.Annotations;
 using System.Net;
 using System.Threading.Tasks;
+using BookingsApi.Common;
 using BookingsApi.Contract.Requests;
 using BookingsApi.DAL.Commands;
 using BookingsApi.DAL.Commands.Core;
@@ -119,6 +121,38 @@ namespace BookingsApi.Controllers
             var list = userList.Select(user => JusticeUserToResponseMapper.Map(user));
 
             return Ok(list.ToList());
+        }
+
+        /// <summary>
+        /// Delete a justice user
+        /// </summary>
+        /// <param name="id">The justice user id</param>
+        /// <returns></returns>
+        [HttpDelete("{id}")]
+        [OpenApiOperation("DeleteJusticeUser")]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NoContent)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> DeleteJusticeUser(Guid id)
+        {
+            if (id == Guid.Empty)
+            {
+                ModelState.AddModelError(nameof(id), $"Please provide a valid {nameof(id)}");
+                return ValidationProblem();
+            }
+
+            var command = new DeleteJusticeUserCommand(id);
+
+            try
+            {
+                await _commandHandler.Handle(command);
+            }
+            catch (JusticeUserNotFoundException e)
+            {
+                return NotFound(e.Message);
+            }
+
+            return NoContent();
         }
     }
 }

--- a/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
+++ b/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
@@ -93,6 +93,7 @@ namespace Testing.Common.Builders.Api
         {
             private const string ApiRoot = "justiceuser";
             public static string AddAJusticeUser => $"{ApiRoot}";
+            public static string DeleteJusticeUser(Guid justiceUserId) => $"{ApiRoot}/{justiceUserId}";
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9367


### Change description ###

- Adds an endpoint for (soft) deleting justice users
- Uses a global filter in the BookingsDbContext to automatically filter deleted justice users and work hours out of queries. This is overridden with IgnoreGlobalFilters() where necessary. More info on this approach here https://learn.microsoft.com/en-us/ef/core/querying/filters


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
