### PR TITLE
VIH-9675 Fix for automation tests creating lots of AAD accounts

### DIFF
--- a/BookingsApi/BookingsApi.AcceptanceTests/Features/Persons.feature
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Features/Persons.feature
@@ -24,13 +24,6 @@ Scenario: Get person by search term
 	Then the response should have the status OK and success status True
 	And persons details should be retrieved
 
-Scenario: Get persons hearings by username for deletion
-	Given I have a hearing
-	And I have a search for hearings by username for removal request
-	When I send the request to the endpoint
-	Then the response should have the status OK and success status True
-	And a list of hearings for deletion is 1
-
 Scenario: Search for an individual by contact email
 	Given I have a hearing
 	And I have a search for an individual request for an individual

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/AddParticipantRequest.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/AddParticipantRequest.cs
@@ -2,24 +2,26 @@
 using BookingsApi.Contract.Requests;
 using FizzWare.NBuilder;
 using Testing.Common.Configuration;
+using Testing.Common.Data;
 
 namespace BookingsApi.AcceptanceTests.Models
 {
     internal static class AddParticipantRequest
     {
+        public static readonly ParticipantRequest User = new TestUser(ParticipantRequestFirstName, ParticipantRequestLastName);
         public const string ParticipantRequestFirstName = TestUsers.ApplicantLitigant2.FirstName;
         private const string ParticipantRequestLastName = TestUsers.ApplicantLitigant2.LastName;
         public static AddParticipantsToHearingRequest BuildRequest()
         {
             var participants = Builder<ParticipantRequest>.CreateListOfSize(1).All()
-                .With(x => x.ContactEmail = $"{ParticipantRequestFirstName}_{ParticipantRequestLastName}@hmcts.net")
-                .With(x => x.Username = $"{ParticipantRequestFirstName}_{ParticipantRequestLastName}@hearings.reform.hmcts.net")
+                .With(x => x.ContactEmail = User.ContactEmail)
+                .With(x => x.Username = User.Username)
                 .With(x => x.TelephoneNumber = "01234567890")
                 .Build().ToList();
             participants[0].CaseRoleName = "Applicant";
             participants[0].HearingRoleName = "Litigant in person";
-            participants[0].FirstName = ParticipantRequestFirstName;
-            participants[0].LastName = ParticipantRequestLastName;
+            participants[0].FirstName = User.FirstName;
+            participants[0].LastName = User.LastName;
             var request = new AddParticipantsToHearingRequest{Participants = participants};
             return request;
         }

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/AddParticipantRequest.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/AddParticipantRequest.cs
@@ -6,17 +6,19 @@ namespace BookingsApi.AcceptanceTests.Models
 {
     internal static class AddParticipantRequest
     {
-        public const string ParticipantRequestFirstName = "Automation_AddedParticipant";
+        public const string ParticipantRequestFirstName = "Automation_Applicant";
+        private const string ParticipantRequestLastName = "LitigantInPerson_2";
         public static AddParticipantsToHearingRequest BuildRequest()
         {
             var participants = Builder<ParticipantRequest>.CreateListOfSize(1).All()
-                .With(x => x.ContactEmail = $"Automation_{Faker.RandomNumber.Next()}@hmcts.net")
-                .With(x => x.Username = $"Automation_{Faker.RandomNumber.Next()}@hmcts.net")
+                .With(x => x.ContactEmail = $"{ParticipantRequestFirstName}_{ParticipantRequestLastName}@hmcts.net")
+                .With(x => x.Username = $"{ParticipantRequestFirstName}_{ParticipantRequestLastName}@hearings.reform.hmcts.net")
                 .With(x => x.TelephoneNumber = "01234567890")
                 .Build().ToList();
             participants[0].CaseRoleName = "Applicant";
             participants[0].HearingRoleName = "Litigant in person";
             participants[0].FirstName = ParticipantRequestFirstName;
+            participants[0].LastName = ParticipantRequestLastName;
             var request = new AddParticipantsToHearingRequest{Participants = participants};
             return request;
         }

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/AddParticipantRequest.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/AddParticipantRequest.cs
@@ -1,13 +1,14 @@
 ﻿using System.Linq;
 using BookingsApi.Contract.Requests;
 using FizzWare.NBuilder;
+using Testing.Common.Configuration;
 
 namespace BookingsApi.AcceptanceTests.Models
 {
     internal static class AddParticipantRequest
     {
-        public const string ParticipantRequestFirstName = "Automation_Applicant";
-        private const string ParticipantRequestLastName = "LitigantInPerson_2";
+        public const string ParticipantRequestFirstName = TestUsers.ApplicantLitigant2.FirstName;
+        private const string ParticipantRequestLastName = TestUsers.ApplicantLitigant2.LastName;
         public static AddParticipantsToHearingRequest BuildRequest()
         {
             var participants = Builder<ParticipantRequest>.CreateListOfSize(1).All()

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/CreateHearingRequestBuilder.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/CreateHearingRequestBuilder.cs
@@ -5,6 +5,7 @@ using BookingsApi.AcceptanceTests.Contexts;
 using BookingsApi.Contract.Requests;
 using FizzWare.NBuilder;
 using Testing.Common.Configuration;
+using Testing.Common.Data;
 
 namespace BookingsApi.AcceptanceTests.Models
 {
@@ -21,50 +22,55 @@ namespace BookingsApi.AcceptanceTests.Models
                 .With(x => x.OrganisationName = TestUsers.Organisation1)
                 .Build().ToList();
 
+            var participant0 = new TestUser(TestUsers.ApplicantLitigant1.FirstName, TestUsers.ApplicantLitigant1.LastName);
             participants[0].CaseRoleName = "Applicant";
             participants[0].HearingRoleName = "Litigant in person";
             participants[0].Representee = null;
-            participants[0].FirstName = TestUsers.ApplicantLitigant1.FirstName;
-            participants[0].LastName = TestUsers.ApplicantLitigant1.LastName;
-            participants[0].ContactEmail = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
-            participants[0].Username = $"{participants[0].FirstName}_{participants[0].LastName}@hearings.reform.hmcts.net";
-            participants[0].DisplayName = $"{participants[0].FirstName} {participants[0].LastName}";
+            participants[0].FirstName = participant0.FirstName;
+            participants[0].LastName = participant0.LastName;
+            participants[0].ContactEmail = participant0.ContactEmail;
+            participants[0].Username = participant0.Username;
+            participants[0].DisplayName = participant0.DisplayName;
 
+            var participant1 = new TestUser(TestUsers.ApplicantRepresentative1.FirstName, TestUsers.ApplicantRepresentative1.LastName);
             participants[1].CaseRoleName = "Applicant";
             participants[1].HearingRoleName = "Representative";
-            participants[1].Representee = participants[0].DisplayName;
-            participants[1].FirstName = TestUsers.ApplicantRepresentative1.FirstName;
-            participants[1].LastName = TestUsers.ApplicantRepresentative1.LastName;
-            participants[1].ContactEmail = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
-            participants[1].Username = $"{participants[1].FirstName}_{participants[1].LastName}@hearings.reform.hmcts.net";
-            participants[1].DisplayName = $"{participants[1].FirstName} {participants[1].LastName}";
+            participants[1].Representee = participant0.DisplayName;
+            participants[1].FirstName = participant1.FirstName;
+            participants[1].LastName = participant1.LastName;
+            participants[1].ContactEmail = participant1.ContactEmail;
+            participants[1].Username = participant1.Username;
+            participants[1].DisplayName = participant1.DisplayName;
 
+            var participant2 = new TestUser(TestUsers.RespondentLitigant1.FirstName, TestUsers.RespondentLitigant1.LastName);
             participants[2].CaseRoleName = "Respondent";
             participants[2].HearingRoleName = "Litigant in person";
             participants[2].Representee = null;
-            participants[2].FirstName = TestUsers.RespondentLitigant1.FirstName;
-            participants[2].LastName = TestUsers.RespondentLitigant1.LastName;
-            participants[2].ContactEmail = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
-            participants[2].Username = $"{participants[2].FirstName}_{participants[2].LastName}@hearings.reform.hmcts.net";
-            participants[2].DisplayName = $"{participants[2].FirstName} {participants[2].LastName}";
+            participants[2].FirstName = participant2.FirstName;
+            participants[2].LastName = participant2.LastName;
+            participants[2].ContactEmail = participant2.ContactEmail;
+            participants[2].Username = participant2.Username;
+            participants[2].DisplayName = participant2.DisplayName;
 
+            var participant3 = new TestUser(TestUsers.RespondentRepresentative1.FirstName, TestUsers.RespondentRepresentative1.LastName);
             participants[3].CaseRoleName = "Respondent";
             participants[3].HearingRoleName = "Representative";
-            participants[3].Representee = participants[2].DisplayName;
-            participants[3].FirstName = TestUsers.RespondentRepresentative1.FirstName;
-            participants[3].LastName = TestUsers.RespondentRepresentative1.LastName;
-            participants[3].ContactEmail = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
-            participants[3].Username = $"{participants[3].FirstName}_{participants[3].LastName}@hearings.reform.hmcts.net";
-            participants[3].DisplayName = $"{participants[3].FirstName} {participants[3].LastName}";
+            participants[3].Representee = participant2.DisplayName;
+            participants[3].FirstName = participant3.FirstName;
+            participants[3].LastName = participant3.LastName;
+            participants[3].ContactEmail = participant3.ContactEmail;
+            participants[3].Username = participant3.Username;
+            participants[3].DisplayName = participant3.DisplayName;
 
+            var participant4 = new TestUser(TestUsers.Judge1.FirstName, TestUsers.Judge1.LastName);
             participants[4].CaseRoleName = "Judge";
             participants[4].HearingRoleName = "Judge";
             participants[4].Representee = null;
-            participants[4].FirstName = TestUsers.Judge1.FirstName;
-            participants[4].LastName = TestUsers.Judge1.LastName;
-            participants[4].ContactEmail = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
-            participants[4].Username = $"{participants[4].FirstName}_{participants[4].LastName}@hearings.reform.hmcts.net";
-            participants[4].DisplayName = $"{participants[4].FirstName} {participants[4].LastName}";
+            participants[4].FirstName = participant4.FirstName;
+            participants[4].LastName = participant4.LastName;
+            participants[4].ContactEmail = participant4.ContactEmail;
+            participants[4].Username = participant4.Username;
+            participants[4].DisplayName = participant4.DisplayName;
 
             var cases = Builder<CaseRequest>.CreateListOfSize(1).Build().ToList();
             cases[0].IsLeadCase = false;
@@ -102,18 +108,17 @@ namespace BookingsApi.AcceptanceTests.Models
 
         public CreateHearingRequestBuilder WithParticipant(string caseRoleName, string hearingRoleName)
         {
-            var firstName = $"Automation_{caseRoleName}";
-            var lastName = $"{hearingRoleName}_1";
+            var user = new TestUser(caseRoleName, $"{hearingRoleName}_1");
             const string organisationName = TestUsers.Organisation1;
             
             var participant = Builder<ParticipantRequest>.CreateNew()
                 .With(x => x.Title = "Mrs")
-                .With(x => x.FirstName = firstName)
-                .With(x => x.LastName = lastName)
-                .With(x => x.ContactEmail = $"{firstName}_{lastName}@hmcts.net")
+                .With(x => x.FirstName = user.FirstName)
+                .With(x => x.LastName = user.LastName)
+                .With(x => x.ContactEmail = user.ContactEmail)
                 .With(x => x.TelephoneNumber = "01234567890")
-                .With(x => x.Username = $"{firstName}_{lastName}@hearings.reform.hmcts.net")
-                .With(x => x.DisplayName = $"{firstName}_{lastName}")
+                .With(x => x.Username = user.Username)
+                .With(x => x.DisplayName = user.DisplayName)
                 .With(x => x.CaseRoleName = caseRoleName)
                 .With(x => x.HearingRoleName = hearingRoleName)
                 .With(x => x.Representee = null)

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/CreateHearingRequestBuilder.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/CreateHearingRequestBuilder.cs
@@ -16,34 +16,54 @@ namespace BookingsApi.AcceptanceTests.Models
         {
             var participants = Builder<ParticipantRequest>.CreateListOfSize(5).All()
                 .With(x => x.Title = "Mrs")
-                .With(x => x.FirstName = $"Automation_{Faker.Name.First()}")
-                .With(x => x.LastName = $"Automation_{Faker.Name.Last()}")
-                .With(x => x.ContactEmail = $"Automation_{Faker.RandomNumber.Next()}@hmcts.net")
                 .With(x => x.TelephoneNumber = "01234567890")
-                .With(x => x.Username = $"Automation_{Faker.RandomNumber.Next()}@hmcts.net")
-                .With(x => x.DisplayName = $"Automation_{Faker.Name.FullName()}")
-                .With(x => x.OrganisationName = $"{Faker.Company.Name()}")
+                .With(x => x.OrganisationName = "Organisation1")
                 .Build().ToList();
 
             participants[0].CaseRoleName = "Applicant";
             participants[0].HearingRoleName = "Litigant in person";
             participants[0].Representee = null;
+            participants[0].FirstName = "Automation_Applicant";
+            participants[0].LastName = "LitigantInPerson_1";
+            participants[0].ContactEmail = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
+            participants[0].Username = $"{participants[0].FirstName}_{participants[0].LastName}@hearings.reform.hmcts.net";
+            participants[0].DisplayName = $"{participants[0].FirstName} {participants[0].LastName}";
 
             participants[1].CaseRoleName = "Applicant";
             participants[1].HearingRoleName = "Representative";
             participants[1].Representee = participants[0].DisplayName;
+            participants[1].FirstName = "Automation_Applicant";
+            participants[1].LastName = "Representative_1";
+            participants[1].ContactEmail = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
+            participants[1].Username = $"{participants[1].FirstName}_{participants[1].LastName}@hearings.reform.hmcts.net";
+            participants[1].DisplayName = $"{participants[1].FirstName} {participants[1].LastName}";
 
             participants[2].CaseRoleName = "Respondent";
             participants[2].HearingRoleName = "Litigant in person";
             participants[2].Representee = null;
+            participants[2].FirstName = "Automation_Respondent";
+            participants[2].LastName = "LitigantInPerson_1";
+            participants[2].ContactEmail = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
+            participants[2].Username = $"{participants[2].FirstName}_{participants[2].LastName}@hearings.reform.hmcts.net";
+            participants[2].DisplayName = $"{participants[2].FirstName} {participants[2].LastName}";
 
             participants[3].CaseRoleName = "Respondent";
             participants[3].HearingRoleName = "Representative";
             participants[3].Representee = participants[2].DisplayName;
+            participants[3].FirstName = "Automation_Respondent";
+            participants[3].LastName = "Representative_1";
+            participants[3].ContactEmail = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
+            participants[3].Username = $"{participants[3].FirstName}_{participants[3].LastName}@hearings.reform.hmcts.net";
+            participants[3].DisplayName = $"{participants[3].FirstName} {participants[3].LastName}";
 
             participants[4].CaseRoleName = "Judge";
             participants[4].HearingRoleName = "Judge";
             participants[4].Representee = null;
+            participants[4].FirstName = "Automation_Judge";
+            participants[4].LastName = "Judge_1";
+            participants[4].ContactEmail = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
+            participants[4].Username = $"{participants[4].FirstName}_{participants[4].LastName}@hearings.reform.hmcts.net";
+            participants[4].DisplayName = $"{participants[4].FirstName} {participants[4].LastName}";
 
             var cases = Builder<CaseRequest>.CreateListOfSize(1).Build().ToList();
             cases[0].IsLeadCase = false;
@@ -81,18 +101,22 @@ namespace BookingsApi.AcceptanceTests.Models
 
         public CreateHearingRequestBuilder WithParticipant(string caseRoleName, string hearingRoleName)
         {
+            var firstName = $"Automation_{caseRoleName}";
+            var lastName = $"{hearingRoleName}_1";
+            const string organisationName = "Organisation1";
+            
             var participant = Builder<ParticipantRequest>.CreateNew()
                 .With(x => x.Title = "Mrs")
-                .With(x => x.FirstName = $"Automation_{Faker.Name.First()}")
-                .With(x => x.LastName = $"Automation_{Faker.Name.Last()}")
-                .With(x => x.ContactEmail = $"Automation_{Faker.RandomNumber.Next()}@hmcts.net")
+                .With(x => x.FirstName = firstName)
+                .With(x => x.LastName = lastName)
+                .With(x => x.ContactEmail = $"{firstName}_{lastName}@hmcts.net")
                 .With(x => x.TelephoneNumber = "01234567890")
-                .With(x => x.Username = hearingRoleName == "Judge" ? $"Automation_{Faker.RandomNumber.Next()}@hmcts.net" : String.Empty)
-                .With(x => x.DisplayName = $"Automation_{Faker.Name.FullName()}")
+                .With(x => x.Username = $"{firstName}_{lastName}@hearings.reform.hmcts.net")
+                .With(x => x.DisplayName = $"{firstName}_{lastName}")
                 .With(x => x.CaseRoleName = caseRoleName)
                 .With(x => x.HearingRoleName = hearingRoleName)
                 .With(x => x.Representee = null)
-                .With(x => x.OrganisationName = $"{Faker.Company.Name()}")
+                .With(x => x.OrganisationName = organisationName)
                 .Build();
 
             _request.Participants.Add(participant);

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/CreateHearingRequestBuilder.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/CreateHearingRequestBuilder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BookingsApi.AcceptanceTests.Contexts;
 using BookingsApi.Contract.Requests;
 using FizzWare.NBuilder;
+using Testing.Common.Configuration;
 
 namespace BookingsApi.AcceptanceTests.Models
 {
@@ -17,14 +18,14 @@ namespace BookingsApi.AcceptanceTests.Models
             var participants = Builder<ParticipantRequest>.CreateListOfSize(5).All()
                 .With(x => x.Title = "Mrs")
                 .With(x => x.TelephoneNumber = "01234567890")
-                .With(x => x.OrganisationName = "Organisation1")
+                .With(x => x.OrganisationName = TestUsers.Organisation1)
                 .Build().ToList();
 
             participants[0].CaseRoleName = "Applicant";
             participants[0].HearingRoleName = "Litigant in person";
             participants[0].Representee = null;
-            participants[0].FirstName = "Automation_Applicant";
-            participants[0].LastName = "LitigantInPerson_1";
+            participants[0].FirstName = TestUsers.ApplicantLitigant1.FirstName;
+            participants[0].LastName = TestUsers.ApplicantLitigant1.LastName;
             participants[0].ContactEmail = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
             participants[0].Username = $"{participants[0].FirstName}_{participants[0].LastName}@hearings.reform.hmcts.net";
             participants[0].DisplayName = $"{participants[0].FirstName} {participants[0].LastName}";
@@ -32,8 +33,8 @@ namespace BookingsApi.AcceptanceTests.Models
             participants[1].CaseRoleName = "Applicant";
             participants[1].HearingRoleName = "Representative";
             participants[1].Representee = participants[0].DisplayName;
-            participants[1].FirstName = "Automation_Applicant";
-            participants[1].LastName = "Representative_1";
+            participants[1].FirstName = TestUsers.ApplicantRepresentative1.FirstName;
+            participants[1].LastName = TestUsers.ApplicantRepresentative1.LastName;
             participants[1].ContactEmail = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
             participants[1].Username = $"{participants[1].FirstName}_{participants[1].LastName}@hearings.reform.hmcts.net";
             participants[1].DisplayName = $"{participants[1].FirstName} {participants[1].LastName}";
@@ -41,8 +42,8 @@ namespace BookingsApi.AcceptanceTests.Models
             participants[2].CaseRoleName = "Respondent";
             participants[2].HearingRoleName = "Litigant in person";
             participants[2].Representee = null;
-            participants[2].FirstName = "Automation_Respondent";
-            participants[2].LastName = "LitigantInPerson_1";
+            participants[2].FirstName = TestUsers.RespondentLitigant1.FirstName;
+            participants[2].LastName = TestUsers.RespondentLitigant1.LastName;
             participants[2].ContactEmail = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
             participants[2].Username = $"{participants[2].FirstName}_{participants[2].LastName}@hearings.reform.hmcts.net";
             participants[2].DisplayName = $"{participants[2].FirstName} {participants[2].LastName}";
@@ -50,8 +51,8 @@ namespace BookingsApi.AcceptanceTests.Models
             participants[3].CaseRoleName = "Respondent";
             participants[3].HearingRoleName = "Representative";
             participants[3].Representee = participants[2].DisplayName;
-            participants[3].FirstName = "Automation_Respondent";
-            participants[3].LastName = "Representative_1";
+            participants[3].FirstName = TestUsers.RespondentRepresentative1.FirstName;
+            participants[3].LastName = TestUsers.RespondentRepresentative1.LastName;
             participants[3].ContactEmail = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
             participants[3].Username = $"{participants[3].FirstName}_{participants[3].LastName}@hearings.reform.hmcts.net";
             participants[3].DisplayName = $"{participants[3].FirstName} {participants[3].LastName}";
@@ -59,8 +60,8 @@ namespace BookingsApi.AcceptanceTests.Models
             participants[4].CaseRoleName = "Judge";
             participants[4].HearingRoleName = "Judge";
             participants[4].Representee = null;
-            participants[4].FirstName = "Automation_Judge";
-            participants[4].LastName = "Judge_1";
+            participants[4].FirstName = TestUsers.Judge1.FirstName;
+            participants[4].LastName = TestUsers.Judge1.LastName;
             participants[4].ContactEmail = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
             participants[4].Username = $"{participants[4].FirstName}_{participants[4].LastName}@hearings.reform.hmcts.net";
             participants[4].DisplayName = $"{participants[4].FirstName} {participants[4].LastName}";
@@ -103,7 +104,7 @@ namespace BookingsApi.AcceptanceTests.Models
         {
             var firstName = $"Automation_{caseRoleName}";
             var lastName = $"{hearingRoleName}_1";
-            const string organisationName = "Organisation1";
+            const string organisationName = TestUsers.Organisation1;
             
             var participant = Builder<ParticipantRequest>.CreateNew()
                 .With(x => x.Title = "Mrs")

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/SimpleBookNewHearingRequest.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/SimpleBookNewHearingRequest.cs
@@ -13,49 +13,56 @@ internal class SimpleBookNewHearingRequest
     public SimpleBookNewHearingRequest(string caseName, DateTime scheduledDateTime, string emailDomain = "@hmcts.net")
     {
         var hearingScheduled = scheduledDateTime;
-        var username1 = $"auto_vw.individual_60{emailDomain}";
-        var username2 = $"auto_vw.representative_13{emailDomain}";
-        var username3 = $"auto_vw.individual_134{emailDomain}";
-        var username4 = $"auto_vw.representative_157{emailDomain}";
-        var username5 = $"auto_aw.judge_02{emailDomain}";
         var participants = Builder<ParticipantRequest>.CreateListOfSize(5).All()
             .With(x => x.Title = "Mrs")
-            .With(x => x.FirstName = $"Automation_{Faker.Name.First()}")
-            .With(x => x.LastName = $"Automation_{Faker.Name.Last()}")
-            .With(x => x.TelephoneNumber = Faker.Phone.Number())
-            .With(x => x.DisplayName = $"Automation_{Faker.Name.FullName()}")
-            .With(x => x.OrganisationName = $"{Faker.Company.Name()}")
+            .With(x => x.TelephoneNumber = "01234567890")
+            .With(x => x.OrganisationName = $"Organisation1")
             .Build().ToList();
 
         participants[0].CaseRoleName = "Applicant";
         participants[0].HearingRoleName = "Litigant in person";
         participants[0].Representee = null;
-        participants[0].Username = username1;
-        participants[0].ContactEmail = username1;
+        participants[0].FirstName = "Automation_Applicant";
+        participants[0].LastName = "LitigantInPerson_1";
+        participants[0].ContactEmail = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
+        participants[0].Username = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
+        participants[0].DisplayName = $"{participants[0].FirstName} {participants[0].LastName}";
 
         participants[1].CaseRoleName = "Applicant";
         participants[1].HearingRoleName = "Representative";
         participants[1].Representee = participants[0].DisplayName;
-        participants[1].Username = username2;
-        participants[1].ContactEmail = username2;
+        participants[1].FirstName = "Automation_Applicant";
+        participants[1].LastName = "Representative_1";
+        participants[1].ContactEmail = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
+        participants[1].Username = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
+        participants[1].DisplayName = $"{participants[1].FirstName} {participants[1].LastName}";
 
         participants[2].CaseRoleName = "Respondent";
         participants[2].HearingRoleName = "Litigant in person";
         participants[2].Representee = null;
-        participants[2].Username = username3;
-        participants[2].ContactEmail = username3;
+        participants[2].FirstName = "Automation_Respondent";
+        participants[2].LastName = "LitigantInPerson_1";
+        participants[2].ContactEmail = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
+        participants[2].Username = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
+        participants[2].DisplayName = $"{participants[2].FirstName} {participants[2].LastName}";
 
         participants[3].CaseRoleName = "Respondent";
         participants[3].HearingRoleName = "Representative";
         participants[3].Representee = participants[2].DisplayName;
-        participants[3].Username = username4;
-        participants[3].ContactEmail = username4;
+        participants[3].FirstName = "Automation_Respondent";
+        participants[3].LastName = "Representative_1";
+        participants[3].ContactEmail = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
+        participants[3].Username = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
+        participants[3].DisplayName = $"{participants[3].FirstName} {participants[3].LastName}";
 
         participants[4].CaseRoleName = "Judge";
         participants[4].HearingRoleName = "Judge";
         participants[4].Representee = null;
-        participants[4].Username = username5;
-        participants[4].ContactEmail = username5;
+        participants[4].FirstName = "Automation_Judge";
+        participants[4].LastName = "Judge_1";
+        participants[4].ContactEmail = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
+        participants[4].Username = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
+        participants[4].DisplayName = $"{participants[4].FirstName} {participants[4].LastName}";
 
         var cases = Builder<CaseRequest>.CreateListOfSize(1).Build().ToList();
         cases[0].IsLeadCase = false;

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/SimpleBookNewHearingRequest.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/SimpleBookNewHearingRequest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BookingsApi.Contract.Requests;
 using FizzWare.NBuilder;
+using Testing.Common.Configuration;
 
 namespace BookingsApi.AcceptanceTests.Models;
 
@@ -16,14 +17,14 @@ internal class SimpleBookNewHearingRequest
         var participants = Builder<ParticipantRequest>.CreateListOfSize(5).All()
             .With(x => x.Title = "Mrs")
             .With(x => x.TelephoneNumber = "01234567890")
-            .With(x => x.OrganisationName = $"Organisation1")
+            .With(x => x.OrganisationName = TestUsers.Organisation1)
             .Build().ToList();
 
         participants[0].CaseRoleName = "Applicant";
         participants[0].HearingRoleName = "Litigant in person";
         participants[0].Representee = null;
-        participants[0].FirstName = "Automation_Applicant";
-        participants[0].LastName = "LitigantInPerson_1";
+        participants[0].FirstName = TestUsers.ApplicantLitigant1.FirstName;
+        participants[0].LastName = TestUsers.ApplicantLitigant1.LastName;
         participants[0].ContactEmail = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
         participants[0].Username = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
         participants[0].DisplayName = $"{participants[0].FirstName} {participants[0].LastName}";
@@ -31,8 +32,8 @@ internal class SimpleBookNewHearingRequest
         participants[1].CaseRoleName = "Applicant";
         participants[1].HearingRoleName = "Representative";
         participants[1].Representee = participants[0].DisplayName;
-        participants[1].FirstName = "Automation_Applicant";
-        participants[1].LastName = "Representative_1";
+        participants[1].FirstName = TestUsers.ApplicantRepresentative1.FirstName;
+        participants[1].LastName = TestUsers.ApplicantRepresentative1.LastName;
         participants[1].ContactEmail = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
         participants[1].Username = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
         participants[1].DisplayName = $"{participants[1].FirstName} {participants[1].LastName}";
@@ -40,8 +41,8 @@ internal class SimpleBookNewHearingRequest
         participants[2].CaseRoleName = "Respondent";
         participants[2].HearingRoleName = "Litigant in person";
         participants[2].Representee = null;
-        participants[2].FirstName = "Automation_Respondent";
-        participants[2].LastName = "LitigantInPerson_1";
+        participants[2].FirstName = TestUsers.RespondentLitigant1.FirstName;
+        participants[2].LastName = TestUsers.RespondentLitigant1.LastName;
         participants[2].ContactEmail = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
         participants[2].Username = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
         participants[2].DisplayName = $"{participants[2].FirstName} {participants[2].LastName}";
@@ -49,8 +50,8 @@ internal class SimpleBookNewHearingRequest
         participants[3].CaseRoleName = "Respondent";
         participants[3].HearingRoleName = "Representative";
         participants[3].Representee = participants[2].DisplayName;
-        participants[3].FirstName = "Automation_Respondent";
-        participants[3].LastName = "Representative_1";
+        participants[3].FirstName = TestUsers.RespondentRepresentative1.FirstName;
+        participants[3].LastName = TestUsers.RespondentRepresentative1.LastName;
         participants[3].ContactEmail = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
         participants[3].Username = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
         participants[3].DisplayName = $"{participants[3].FirstName} {participants[3].LastName}";
@@ -58,8 +59,8 @@ internal class SimpleBookNewHearingRequest
         participants[4].CaseRoleName = "Judge";
         participants[4].HearingRoleName = "Judge";
         participants[4].Representee = null;
-        participants[4].FirstName = "Automation_Judge";
-        participants[4].LastName = "Judge_1";
+        participants[4].FirstName = TestUsers.Judge1.FirstName;
+        participants[4].LastName = TestUsers.Judge1.LastName;
         participants[4].ContactEmail = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
         participants[4].Username = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
         participants[4].DisplayName = $"{participants[4].FirstName} {participants[4].LastName}";

--- a/BookingsApi/BookingsApi.AcceptanceTests/Models/SimpleBookNewHearingRequest.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Models/SimpleBookNewHearingRequest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BookingsApi.Contract.Requests;
 using FizzWare.NBuilder;
 using Testing.Common.Configuration;
+using Testing.Common.Data;
 
 namespace BookingsApi.AcceptanceTests.Models;
 
@@ -11,7 +12,7 @@ internal class SimpleBookNewHearingRequest
 {
     private readonly BookNewHearingRequest _request;
 
-    public SimpleBookNewHearingRequest(string caseName, DateTime scheduledDateTime, string emailDomain = "@hmcts.net")
+    public SimpleBookNewHearingRequest(string caseName, DateTime scheduledDateTime)
     {
         var hearingScheduled = scheduledDateTime;
         var participants = Builder<ParticipantRequest>.CreateListOfSize(5).All()
@@ -20,50 +21,55 @@ internal class SimpleBookNewHearingRequest
             .With(x => x.OrganisationName = TestUsers.Organisation1)
             .Build().ToList();
 
+        var participant0 = new TestUser(TestUsers.ApplicantLitigant1.FirstName, TestUsers.ApplicantLitigant1.LastName);
         participants[0].CaseRoleName = "Applicant";
         participants[0].HearingRoleName = "Litigant in person";
         participants[0].Representee = null;
-        participants[0].FirstName = TestUsers.ApplicantLitigant1.FirstName;
-        participants[0].LastName = TestUsers.ApplicantLitigant1.LastName;
-        participants[0].ContactEmail = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
-        participants[0].Username = $"{participants[0].FirstName}_{participants[0].LastName}@hmcts.net";
-        participants[0].DisplayName = $"{participants[0].FirstName} {participants[0].LastName}";
+        participants[0].FirstName = participant0.FirstName;
+        participants[0].LastName = participant0.LastName;
+        participants[0].ContactEmail = participant0.ContactEmail;
+        participants[0].Username = participant0.Username;
+        participants[0].DisplayName = participant0.DisplayName;
 
+        var participant1 = new TestUser(TestUsers.ApplicantRepresentative1.FirstName, TestUsers.ApplicantRepresentative1.LastName);
         participants[1].CaseRoleName = "Applicant";
         participants[1].HearingRoleName = "Representative";
-        participants[1].Representee = participants[0].DisplayName;
-        participants[1].FirstName = TestUsers.ApplicantRepresentative1.FirstName;
-        participants[1].LastName = TestUsers.ApplicantRepresentative1.LastName;
-        participants[1].ContactEmail = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
-        participants[1].Username = $"{participants[1].FirstName}_{participants[1].LastName}@hmcts.net";
-        participants[1].DisplayName = $"{participants[1].FirstName} {participants[1].LastName}";
+        participants[1].Representee = participant0.DisplayName;
+        participants[1].FirstName = participant1.FirstName;
+        participants[1].LastName = participant1.LastName;
+        participants[1].ContactEmail = participant1.ContactEmail;
+        participants[1].Username = participant1.Username;
+        participants[1].DisplayName = participant1.DisplayName;
 
+        var participant2 = new TestUser(TestUsers.RespondentLitigant1.FirstName, TestUsers.RespondentLitigant1.LastName);
         participants[2].CaseRoleName = "Respondent";
         participants[2].HearingRoleName = "Litigant in person";
         participants[2].Representee = null;
-        participants[2].FirstName = TestUsers.RespondentLitigant1.FirstName;
-        participants[2].LastName = TestUsers.RespondentLitigant1.LastName;
-        participants[2].ContactEmail = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
-        participants[2].Username = $"{participants[2].FirstName}_{participants[2].LastName}@hmcts.net";
-        participants[2].DisplayName = $"{participants[2].FirstName} {participants[2].LastName}";
+        participants[2].FirstName = participant2.FirstName;
+        participants[2].LastName = participant2.LastName;
+        participants[2].ContactEmail = participant2.ContactEmail;
+        participants[2].Username = participant2.Username;
+        participants[2].DisplayName = participant2.DisplayName;
 
+        var participant3 = new TestUser(TestUsers.RespondentRepresentative1.FirstName, TestUsers.RespondentRepresentative1.LastName);
         participants[3].CaseRoleName = "Respondent";
         participants[3].HearingRoleName = "Representative";
-        participants[3].Representee = participants[2].DisplayName;
-        participants[3].FirstName = TestUsers.RespondentRepresentative1.FirstName;
-        participants[3].LastName = TestUsers.RespondentRepresentative1.LastName;
-        participants[3].ContactEmail = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
-        participants[3].Username = $"{participants[3].FirstName}_{participants[3].LastName}@hmcts.net";
-        participants[3].DisplayName = $"{participants[3].FirstName} {participants[3].LastName}";
+        participants[3].Representee = participant2.DisplayName;
+        participants[3].FirstName = participant3.FirstName;
+        participants[3].LastName = participant3.LastName;
+        participants[3].ContactEmail = participant3.ContactEmail;
+        participants[3].Username = participant3.Username;
+        participants[3].DisplayName = participant3.DisplayName;
 
+        var participant4 = new TestUser(TestUsers.Judge1.FirstName, TestUsers.Judge1.LastName);
         participants[4].CaseRoleName = "Judge";
         participants[4].HearingRoleName = "Judge";
         participants[4].Representee = null;
-        participants[4].FirstName = TestUsers.Judge1.FirstName;
-        participants[4].LastName = TestUsers.Judge1.LastName;
-        participants[4].ContactEmail = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
-        participants[4].Username = $"{participants[4].FirstName}_{participants[4].LastName}@hmcts.net";
-        participants[4].DisplayName = $"{participants[4].FirstName} {participants[4].LastName}";
+        participants[4].FirstName = participant4.FirstName;
+        participants[4].LastName = participant4.LastName;
+        participants[4].ContactEmail = participant4.ContactEmail;
+        participants[4].Username = participant4.Username;
+        participants[4].DisplayName = participant4.DisplayName;
 
         var cases = Builder<CaseRequest>.CreateListOfSize(1).Build().ToList();
         cases[0].IsLeadCase = false;

--- a/BookingsApi/BookingsApi.AcceptanceTests/Steps/HearingsSteps.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Steps/HearingsSteps.cs
@@ -252,7 +252,8 @@ namespace BookingsApi.AcceptanceTests.Steps
             _context.TestData.Hearing.Id = model.OrderByDescending(h => h.ScheduledDateTime).First().Id;
 
             var hearing = model.FirstOrDefault(h => h.Id == _context.TestData.Hearing.Id);
-            Debug.Assert(hearing != null, nameof(hearing) + " != null");
+            hearing.Should().NotBeNull();
+            if (hearing == null) return;
             
             hearing.CaseTypeName.Should().NotBeNullOrEmpty();
             foreach (var theCase in hearing.Cases)

--- a/BookingsApi/BookingsApi.AcceptanceTests/Steps/HearingsSteps.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Steps/HearingsSteps.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using AcceptanceTests.Common.Api.Helpers;
@@ -248,45 +249,45 @@ namespace BookingsApi.AcceptanceTests.Steps
         {
             var model = RequestHelper.Deserialise<List<HearingDetailsResponse>>(_context.Response.Content);
             model.Should().NotBeNull();
-            _context.TestData.Hearing.Id = model.First().Id;
+            _context.TestData.Hearing.Id = model.OrderByDescending(h => h.ScheduledDateTime).First().Id;
 
-            foreach (var hearing in model)
+            var hearing = model.FirstOrDefault(h => h.Id == _context.TestData.Hearing.Id);
+            Debug.Assert(hearing != null, nameof(hearing) + " != null");
+            
+            hearing.CaseTypeName.Should().NotBeNullOrEmpty();
+            foreach (var theCase in hearing.Cases)
             {
-                hearing.CaseTypeName.Should().NotBeNullOrEmpty();
-                foreach (var theCase in hearing.Cases)
-                {
-                    theCase.Name.Should().NotBeNullOrEmpty();
-                    theCase.Number.Should().NotBeNullOrEmpty();
-                }
-                hearing.HearingTypeName.Should().NotBeNullOrEmpty();
-                hearing.HearingVenueName.Should().NotBeNullOrEmpty();
-                foreach (var participant in hearing.Participants)
-                {
-                    participant.CaseRoleName.Should().NotBeNullOrEmpty();
-                    participant.ContactEmail.Should().NotBeNullOrEmpty();
-                    participant.DisplayName.Should().NotBeNullOrEmpty();
-                    participant.FirstName.Should().NotBeNullOrEmpty();
-                    participant.HearingRoleName.Should().NotBeNullOrEmpty();
-                    participant.Id.Should().NotBeEmpty();
-                    participant.LastName.Should().NotBeNullOrEmpty();
-                    participant.MiddleNames.Should().NotBeNullOrEmpty();
-                    participant.TelephoneNumber.Should().NotBeNullOrEmpty();
-                    participant.Title.Should().NotBeNullOrEmpty();
-                    participant.UserRoleName.Should().NotBeNullOrEmpty();
-                }
-                hearing.ScheduledDateTime.Should().BeAfter(DateTime.MinValue);
-                hearing.ScheduledDuration.Should().BePositive();
-                hearing.HearingRoomName.Should().NotBeNullOrEmpty();
-                hearing.OtherInformation.Should().NotBeNullOrEmpty();
-                hearing.CreatedBy.Should().NotBeNullOrEmpty();
-                hearing.Endpoints.Should().NotBeNullOrEmpty();
-                foreach (var endpoint in hearing.Endpoints)
-                {
-                    endpoint.Id.Should().NotBeEmpty();
-                    endpoint.DisplayName.Should().NotBeNullOrEmpty();
-                    endpoint.Sip.Should().NotBeNullOrEmpty();
-                    endpoint.Pin.Should().NotBeNullOrEmpty();
-                }
+                theCase.Name.Should().NotBeNullOrEmpty();
+                theCase.Number.Should().NotBeNullOrEmpty();
+            }
+            hearing.HearingTypeName.Should().NotBeNullOrEmpty();
+            hearing.HearingVenueName.Should().NotBeNullOrEmpty();
+            foreach (var participant in hearing.Participants)
+            {
+                participant.CaseRoleName.Should().NotBeNullOrEmpty();
+                participant.ContactEmail.Should().NotBeNullOrEmpty();
+                participant.DisplayName.Should().NotBeNullOrEmpty();
+                participant.FirstName.Should().NotBeNullOrEmpty();
+                participant.HearingRoleName.Should().NotBeNullOrEmpty();
+                participant.Id.Should().NotBeEmpty();
+                participant.LastName.Should().NotBeNullOrEmpty();
+                participant.MiddleNames.Should().NotBeNullOrEmpty();
+                participant.TelephoneNumber.Should().NotBeNullOrEmpty();
+                participant.Title.Should().NotBeNullOrEmpty();
+                participant.UserRoleName.Should().NotBeNullOrEmpty();
+            }
+            hearing.ScheduledDateTime.Should().BeAfter(DateTime.MinValue);
+            hearing.ScheduledDuration.Should().BePositive();
+            hearing.HearingRoomName.Should().NotBeNullOrEmpty();
+            hearing.OtherInformation.Should().NotBeNullOrEmpty();
+            hearing.CreatedBy.Should().NotBeNullOrEmpty();
+            hearing.Endpoints.Should().NotBeNullOrEmpty();
+            foreach (var endpoint in hearing.Endpoints)
+            {
+                endpoint.Id.Should().NotBeEmpty();
+                endpoint.DisplayName.Should().NotBeNullOrEmpty();
+                endpoint.Sip.Should().NotBeNullOrEmpty();
+                endpoint.Pin.Should().NotBeNullOrEmpty();
             }
         }
 

--- a/BookingsApi/BookingsApi.AcceptanceTests/Steps/ParticipantsSteps.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Steps/ParticipantsSteps.cs
@@ -101,7 +101,7 @@ namespace BookingsApi.AcceptanceTests.Steps
             _context.Request = _context.Get(GetAllParticipantsInHearing(_context.TestData.Hearing.Id));
             _context.Response = _context.Client().Execute(_context.Request);
             var model = RequestHelper.Deserialise<List<ParticipantResponse>>(_context.Response.Content);
-            model.Exists(x => x.FirstName == AddParticipantRequest.ParticipantRequestFirstName).Should().BeTrue();
+            model.Exists(x => x.FirstName == AddParticipantRequest.User.FirstName).Should().BeTrue();
         }
 
         [Then(@"the participant should be removed")]

--- a/BookingsApi/BookingsApi.AcceptanceTests/Steps/PersonsSteps.cs
+++ b/BookingsApi/BookingsApi.AcceptanceTests/Steps/PersonsSteps.cs
@@ -34,14 +34,6 @@ namespace BookingsApi.AcceptanceTests.Steps
             _context.Request =
                 _context.Get(GetPersonByContactEmail(_context.TestData.ParticipantsResponses[0].ContactEmail));
         }
-        
-        [Given(@"I have a search for hearings by username for removal request")]
-        public void GivenIHaveASearchForHearingsByUsernameForRemovalRequest()
-        {
-            var participant = _context.TestData.ParticipantsResponses.First(x => x.UserRoleName.ToLower() != "judge");
-            _context.Request =
-                _context.Get(GetHearingsByUsernameForDeletion(participant.Username));
-        }
 
         [Then(@"a person should be retrieved")]
         public void ThenAPersonShouldBeRetrieved()

--- a/BookingsApi/Testing.Common/Configuration/TestUsers.cs
+++ b/BookingsApi/Testing.Common/Configuration/TestUsers.cs
@@ -1,0 +1,43 @@
+namespace Testing.Common.Configuration
+{
+    public static class TestUsers
+    {
+        public static class ApplicantLitigant1
+        {
+            public const string FirstName = "Automation_Applicant";
+            public const string LastName = "LitigantInPerson_1";
+        }
+        
+        public static class ApplicantLitigant2
+        {
+            public const string FirstName = "Automation_Applicant";
+            public const string LastName = "LitigantInPerson_2";
+        }
+        
+        public static class ApplicantRepresentative1
+        {
+            public const string FirstName = "Automation_Applicant";
+            public const string LastName = "Representative_1";
+        }
+        
+        public static class RespondentLitigant1
+        {
+            public const string FirstName = "Automation_Respondent";
+            public const string LastName = "LitigantInPerson_1";
+        }
+        
+        public static class RespondentRepresentative1
+        {
+            public const string FirstName = "Automation_Respondent";
+            public const string LastName = "Representative_1";
+        }
+        
+        public static class Judge1
+        {
+            public const string FirstName = "Automation_Judge";
+            public const string LastName = "Judge_1";
+        }
+
+        public const string Organisation1 = "Organisation1";
+    }
+}

--- a/BookingsApi/Testing.Common/Data/TestUser.cs
+++ b/BookingsApi/Testing.Common/Data/TestUser.cs
@@ -1,0 +1,15 @@
+using BookingsApi.Contract.Requests;
+namespace Testing.Common.Data
+{
+    public class TestUser : ParticipantRequest
+    {
+        public TestUser(string firstName, string lastName)
+        {
+            FirstName = TestUsers.FirstNamePrefix + firstName;
+            LastName = lastName;
+            ContactEmail = $"{firstName}_{lastName}@hmcts.net";
+            Username = $"{firstName}_{lastName}@hearings.reform.hmcts.net";
+            DisplayName = $"{firstName} {lastName}";
+        }
+    }
+}

--- a/BookingsApi/Testing.Common/Data/TestUser.cs
+++ b/BookingsApi/Testing.Common/Data/TestUser.cs
@@ -6,11 +6,13 @@ namespace Testing.Common.Data
     {
         public TestUser(string firstName, string lastName)
         {
-            FirstName = TestUsers.FirstNamePrefix + firstName;
+            var fullFirstName = TestUsers.FirstNamePrefix + firstName;
+            
+            FirstName = fullFirstName;
             LastName = lastName;
-            ContactEmail = $"{firstName}_{lastName}@hmcts.net";
-            Username = $"{firstName}_{lastName}@hearings.reform.hmcts.net";
-            DisplayName = $"{firstName} {lastName}";
+            ContactEmail = $"{fullFirstName}_{lastName}@hmcts.net";
+            Username = $"{fullFirstName}_{lastName}@hearings.reform.hmcts.net";
+            DisplayName = $"{fullFirstName} {lastName}";
         }
     }
 }

--- a/BookingsApi/Testing.Common/Data/TestUser.cs
+++ b/BookingsApi/Testing.Common/Data/TestUser.cs
@@ -1,4 +1,5 @@
 using BookingsApi.Contract.Requests;
+
 namespace Testing.Common.Data
 {
     public class TestUser : ParticipantRequest

--- a/BookingsApi/Testing.Common/Data/TestUsers.cs
+++ b/BookingsApi/Testing.Common/Data/TestUsers.cs
@@ -1,43 +1,44 @@
-namespace Testing.Common.Configuration
+namespace Testing.Common.Data
 {
     public static class TestUsers
     {
+        public const string FirstNamePrefix = "Automation_";
+        public const string Organisation1 = "Organisation1";
+        
         public static class ApplicantLitigant1
         {
-            public const string FirstName = "Automation_Applicant";
+            public const string FirstName = "Applicant";
             public const string LastName = "LitigantInPerson_1";
         }
         
         public static class ApplicantLitigant2
         {
-            public const string FirstName = "Automation_Applicant";
+            public const string FirstName = "Applicant";
             public const string LastName = "LitigantInPerson_2";
         }
         
         public static class ApplicantRepresentative1
         {
-            public const string FirstName = "Automation_Applicant";
+            public const string FirstName = "Applicant";
             public const string LastName = "Representative_1";
         }
         
         public static class RespondentLitigant1
         {
-            public const string FirstName = "Automation_Respondent";
+            public const string FirstName = "Respondent";
             public const string LastName = "LitigantInPerson_1";
         }
         
         public static class RespondentRepresentative1
         {
-            public const string FirstName = "Automation_Respondent";
+            public const string FirstName = "Respondent";
             public const string LastName = "Representative_1";
         }
         
         public static class Judge1
         {
-            public const string FirstName = "Automation_Judge";
+            public const string FirstName = "Judge";
             public const string LastName = "Judge_1";
         }
-
-        public const string Organisation1 = "Organisation1";
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9675


### Change description ###
Changes the acceptance tests to use an existing set of users rather than create new ones. These users have been added to an "Automation Tests" group in AAD so we know not to delete them.
Removes a test that is no longer valid now that we re-use users, there is already test coverage for that scenario in the integration tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
