### PR TITLE
VIH-9728 Return generic case type hearings based on config

### DIFF
--- a/BookingsApi/BookingsApi.Common/Configuration/SettingsConfiguration.cs
+++ b/BookingsApi/BookingsApi.Common/Configuration/SettingsConfiguration.cs
@@ -3,5 +3,6 @@
     public class SettingsConfiguration
     {
         public bool DisableHttpsRedirection { get; set; }
+        public bool AllowGenericHearingTypes { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.DAL/Queries/GetAllocationHearingsBySearchQuery.cs
+++ b/BookingsApi/BookingsApi.DAL/Queries/GetAllocationHearingsBySearchQuery.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BookingsApi.Common.Configuration;
 using BookingsApi.Contract.Helper;
 using BookingsApi.Domain;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.DAL.Queries.Core;
 using Castle.Core.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace BookingsApi.DAL.Queries
 {
@@ -44,12 +46,12 @@ namespace BookingsApi.DAL.Queries
     public class GetAllocationHearingsBySearchQueryHandler : IQueryHandler<GetAllocationHearingsBySearchQuery, List<VideoHearing>>
     {
         private readonly BookingsDbContext _context;
-        private readonly bool _isTest;
+        private readonly bool _includeGenericHearingTypes;
 
-        public GetAllocationHearingsBySearchQueryHandler(BookingsDbContext context, bool isTest = false)
+        public GetAllocationHearingsBySearchQueryHandler(BookingsDbContext context, IOptions<SettingsConfiguration> configuration)
         {
             _context = context;
-            _isTest = isTest;
+            _includeGenericHearingTypes = configuration.Value.AllowGenericHearingTypes;
         }
         
         public async Task<List<VideoHearing>> Handle(GetAllocationHearingsBySearchQuery query)
@@ -65,7 +67,7 @@ namespace BookingsApi.DAL.Queries
                          && HearingAllocationExcludedVenueList.ExcludedHearingVenueNames.All(venueName => venueName != x.HearingVenueName))
                 .AsQueryable();
             
-            if (!_isTest)
+            if (!_includeGenericHearingTypes)
                 hearings = hearings.Where(h1 => h1.CaseTypeId != 3); //exclude generic type test cases from prod
             
             if (query.IsUnallocated)

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/WorkAllocation/GetUnallocatedHearingsTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/WorkAllocation/GetUnallocatedHearingsTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using BookingsApi.Contract.Responses;
+using BookingsApi.IntegrationTests.Helper;
+using FluentAssertions;
+using NUnit.Framework;
+using Testing.Common.Builders.Api;
+
+namespace BookingsApi.IntegrationTests.Api.WorkAllocation;
+
+public class GetUnallocatedHearingsTests : ApiTest
+{
+    [Test]
+    public async Task should_return_unallocated_hearings_with_generic_case_type()
+    {
+        // arrange
+        using var client = Application.CreateClient();
+        var hearing = await TestDataManager.SeedVideoHearing();
+        var uri = ApiUriFactory.WorkAllocationEndpoints.GetUnallocatedHearings;
+        
+        // act
+        var result = await client.GetAsync(uri);
+
+        // assert
+        result.IsSuccessStatusCode.Should().BeTrue();
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await ApiClientResponse.GetResponses<List<HearingDetailsResponse>>(result.Content);
+        response.Find(x => x.Id == hearing.Id).Should().NotBeNull();
+        response.Should().Contain(x => x.Id == hearing.Id);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await TestDataManager.ClearSeededHearings();
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/ApiTest.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/ApiTest.cs
@@ -11,7 +11,7 @@ public class ApiTest
 {
     protected VhApiWebApplicationFactory Application = null!;
     protected DbContextOptions<BookingsDbContext> BookingsDbContextOptions { get; set; }
-    protected TestDataManager Hooks { get; private set; }
+    protected TestDataManager TestDataManager { get; private set; }
     private IConfigurationRoot _configRoot;
     private string _databaseConnectionString;
 
@@ -35,7 +35,7 @@ public class ApiTest
         TestContext.WriteLine($"Connection string: {_databaseConnectionString}");
         dbContextOptionsBuilder.UseSqlServer(_databaseConnectionString);
         BookingsDbContextOptions = dbContextOptionsBuilder.Options;
-        Hooks = new TestDataManager(BookingsDbContextOptions, "Bookings Api Integration Test");
+        TestDataManager = new TestDataManager(BookingsDbContextOptions, "Bookings Api Integration Test");
 
         var context = new BookingsDbContext(BookingsDbContextOptions);
         context.Database.Migrate();

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetAllocationHearingsBySearchQueryTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetAllocationHearingsBySearchQueryTests.cs
@@ -50,9 +50,20 @@ public class GetAllocationHearingsBySearchQueryTests : DatabaseTestsBase
         {
             options.ScheduledDate = _testDate1;
         });
-       
-       
+    }
 
+    [Test]
+    public async Task Should_ignore_generic_case_type_app_setting_set_to_ignore_generic_hearings()
+    {
+        _handler = new GetAllocationHearingsBySearchQueryHandler(_context,
+            Options.Create(new SettingsConfiguration {AllowGenericHearingTypes = false}));
+        
+        //ACT
+        var hearings = await _handler.Handle(new GetAllocationHearingsBySearchQuery());
+        //ASSERT
+        hearings.Count.Should().Be(2);
+        foreach (var hearing in hearings)
+            hearing.CaseType.Name.Should().Be(TestCaseType);
     }
     
     [Test]
@@ -129,11 +140,13 @@ public class GetAllocationHearingsBySearchQueryTests : DatabaseTestsBase
         var hearings = await _handler.Handle(new GetAllocationHearingsBySearchQuery(isUnallocated:true));
 
         //ASSERT
-        hearings.Count.Should().Be(2);
         hearings.Should().Contain(e =>
-            e.HearingCases.First().Case.Number == _seededHearing1.HearingCases.First().Case.Number);
+            e.GetCases().First().Number == _seededHearing1.GetCases().First().Number);
         hearings.Should().Contain(e => 
-            e.HearingCases.First().Case.Number == _seededHearing3.HearingCases.First().Case.Number);
+            e.GetCases().First().Number == _seededHearing3.GetCases().First().Number);
+        
+        hearings.Should().NotContain(e =>
+            e.GetCases().First().Number == _seededHearing2.GetCases().First().Number);
     }
     
     [Test]

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetAllocationHearingsBySearchQueryTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetAllocationHearingsBySearchQueryTests.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BookingsApi.Common.Configuration;
 using BookingsApi.DAL;
 using BookingsApi.DAL.Queries;
 using BookingsApi.Domain;
 using BookingsApi.Domain.Enumerations;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using NuGet.Packaging;
 using NUnit.Framework;
 using DayOfWeek = System.DayOfWeek;
@@ -31,7 +33,9 @@ public class GetAllocationHearingsBySearchQueryTests : DatabaseTestsBase
     public async Task Setup()
     {
         _context = new BookingsDbContext(BookingsDbContextOptions);
-        _handler = new GetAllocationHearingsBySearchQueryHandler(_context, isTest: true);
+
+        _handler = new GetAllocationHearingsBySearchQueryHandler(_context,
+            Options.Create(new SettingsConfiguration {AllowGenericHearingTypes = true}));
         _seededHearing1 = await Hooks.SeedVideoHearing(status: BookingStatus.Created, configureOptions: options =>
         {
             options.CaseTypeName = TestCaseType;
@@ -246,7 +250,7 @@ public class GetAllocationHearingsBySearchQueryTests : DatabaseTestsBase
 
         await _context.SaveChangesAsync();
         
-        justiceUser = _context.JusticeUsers.FirstOrDefault(x => x.Id == justiceUser.Id);
+        justiceUser = _context.JusticeUsers.First(x => x.Id == justiceUser.Id);
         
         justiceUser.Delete();
         

--- a/BookingsApi/BookingsApi.IntegrationTests/appsettings.json
+++ b/BookingsApi/BookingsApi.IntegrationTests/appsettings.json
@@ -27,6 +27,7 @@
     "UsernameStem": "UsernameStem"
   },
   "UseServiceBusFake": true,
+  "AllowGenericHearingTypes": true,
   "ZapConfiguration": {
     "ApiAddress": "127.0.0.1",
     "ApiPort": "8080",

--- a/BookingsApi/BookingsApi/Startup.cs
+++ b/BookingsApi/BookingsApi/Startup.cs
@@ -74,6 +74,7 @@ namespace BookingsApi
         private void RegisterSettings(IServiceCollection services)
         {
             SettingsConfiguration = Configuration.Get<SettingsConfiguration>();
+            services.Configure<SettingsConfiguration>(Configuration);
             services.Configure<AzureAdConfiguration>(options => Configuration.Bind("AzureAd", options));
             services.Configure<ServiceBusSettings>(options => Configuration.Bind("ServiceBusQueue", options));
             services.Configure<ServicesConfiguration>(options => Configuration.Bind("Services", options));

--- a/BookingsApi/BookingsApi/appsettings.Development.json
+++ b/BookingsApi/BookingsApi/appsettings.Development.json
@@ -5,5 +5,6 @@
       "System": "Warning",
       "Microsoft": "Warning"
     }
-  }
+  },
+  "AllowGenericHearingTypes": true
 }

--- a/BookingsApi/BookingsApi/appsettings.json
+++ b/BookingsApi/BookingsApi/appsettings.json
@@ -16,6 +16,7 @@
     "QueueName": "booking"
   },
   "UseServiceBusFake":  true,
+  "AllowGenericHearingTypes": false,
   "AllocateHearing": {
     "AllowHearingToStartBeforeWorkStartTime": false,
     "AllowHearingToEndAfterWorkEndTime": true,

--- a/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
+++ b/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
@@ -97,5 +97,12 @@ namespace Testing.Common.Builders.Api
             public static string RestoreJusticeUser => $"{ApiRoot}/restore";
             public static string EditJusticeUser => $"{ApiRoot}";
         }
+
+        public static class WorkAllocationEndpoints
+        {
+            private const string ApiRoot = "hearings";
+            
+            public static string GetUnallocatedHearings => $"{ApiRoot}/unallocated";
+        }
     }
 }

--- a/charts/vh-bookings-api/Chart.yaml
+++ b/charts/vh-bookings-api/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: vh-bookings-api
 home: https://github.com/hmcts/vh-bookings-api
-version: 0.0.9
+version: 0.0.10
 description: Helm Chart for bookings Hearing bookings-api
 maintainers:
   - name: VH Devops

--- a/charts/vh-bookings-api/values.dev.template.yaml
+++ b/charts/vh-bookings-api/values.dev.template.yaml
@@ -1,5 +1,7 @@
 ---
 java:
-  image: '${IMAGE_NAME}'
+  image: "${IMAGE_NAME}"
   ingressHost: ${SERVICE_FQDN}
   releaseNameOverride: ${RELEASE_NAME}
+  environment:
+    AllowGenericHearingTypes: true

--- a/charts/vh-bookings-api/values.yaml
+++ b/charts/vh-bookings-api/values.yaml
@@ -1,6 +1,6 @@
 ---
 java:
-  image: 'sdshmctspublic.azurecr.io/vh/bookings-api:latest'
+  image: "sdshmctspublic.azurecr.io/vh/bookings-api:latest"
   applicationPort: 8080
   ingressHost: vh-bookings-api.{{ .Values.global.environment }}.platform.hmcts.net
   releaseNameOverride: vh-bookings-api
@@ -44,3 +44,4 @@ java:
     SERVICEBUSQUEUE__QUEUENAME: booking
     TESTING__TESTUSERNAMESTEM: "@hearings.reform.hmcts.net"
     UseServiceBusFake: false
+    AllowGenericHearingTypes: false


### PR DESCRIPTION
### JIRA link (if applicable) ###
VIH-972


### Change description ###

* Add an app setting `AllowGenericHearingTypes` to toggle whether or not to return hearings with the case type Generic
  * Turn this on for lower environments so that hearings created by automated tests will be visible


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
