### PR TITLE
VIH-10032 45 hearings not automatically allocated for performance test

### DIFF
--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -382,7 +382,13 @@ namespace BookingsApi.Domain
                 .Where(a => a.Hearing.ScheduledDateTime.AddMinutes(a.Hearing.ScheduledDuration + configuration.MinimumGapBetweenHearingsInMinutes) >= ScheduledDateTime)
                 .ToList();
 
-            var gapBetweenHearingsIsInsufficient = allocations.Any(a => (ScheduledDateTime - a.Hearing.ScheduledDateTime).TotalMinutes < configuration.MinimumGapBetweenHearingsInMinutes);
+            var gapBetweenHearingsIsInsufficient = allocations.Exists(a =>
+            {
+                var timeDifferenceInMinutes = Math.Abs((ScheduledDateTime - a.Hearing.ScheduledDateTime).TotalMinutes);
+
+                return timeDifferenceInMinutes < configuration.MinimumGapBetweenHearingsInMinutes;
+            });
+            
             if (gapBetweenHearingsIsInsufficient)
             {
                 return false;

--- a/BookingsApi/BookingsApi.UnitTests/DAL/Services/HearingAllocationServiceTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/DAL/Services/HearingAllocationServiceTests.cs
@@ -818,7 +818,7 @@ namespace BookingsApi.UnitTests.DAL.Services
         }
 
         [Test]
-        public async Task AllocateAutomatically_Should_Ignore_Future_Allocations()
+        public async Task AllocateAutomatically_Should_Allocate_Successfully_With_Future_Allocations_Present()
         {
             // If a user has been allocated to a hearing for a future date, they should still be a candidate for allocation before this date
             


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-10032


### Change description ###
Fixes an issue whereby a CSO cannot be automatically allocated to a hearing if they have already been allocated to another hearing after this date.
Use `Math.Abs` to ensure the time difference between hearings is always output as a positive value. This prevents `gapBetweenHearingsIsInsufficient` from always returning true when the scheduled date time of the hearing is before the scheduled date time of their allocated hearings.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
