### PR TITLE
VIH-10255 bug fix hearing change validation to only apply to confirmed hearings

### DIFF
--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -178,7 +178,7 @@ namespace BookingsApi.Domain
 
         public Participant AddIndividual(Person person, HearingRole hearingRole, CaseRole caseRole, string displayName)
         {
-            if (hearingRole.IsInterpreter() && IsHearingCloseToScheduledStartTime())
+            if (hearingRole.IsInterpreter() && IsHearingConfirmedAndCloseToStartTime())
             {
                 throw new DomainRuleException("Hearing", DomainRuleErrorMessages.CannotAddInterpreterToHearingCloseToStartTime);
             }
@@ -665,7 +665,7 @@ namespace BookingsApi.Domain
                 throw new DomainRuleException("Hearing", errorMessage ?? DomainRuleErrorMessages.CannotEditACancelledHearing);
             }
             
-            if (Status == BookingStatus.Created && IsHearingCloseToScheduledStartTime())
+            if (Status == BookingStatus.Created && IsHearingConfirmedAndCloseToStartTime())
             {
                 throw new DomainRuleException("Hearing", errorMessage ?? DomainRuleErrorMessages.DefaultCannotEditAHearingCloseToStartTime);
             }
@@ -736,7 +736,9 @@ namespace BookingsApi.Domain
                 };
         }
 
-        private bool IsHearingCloseToScheduledStartTime() => ScheduledDateTime.AddMinutes(-30) <= DateTime.UtcNow;
+        private bool IsHearingConfirmedAndCloseToStartTime() => ScheduledDateTime.AddMinutes(-30) <= DateTime.UtcNow &&
+                                                                (Status == BookingStatus.Created ||
+                                                                 Status == BookingStatus.ConfirmedWithoutJudge);
 
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10255

### Change description ###

Booking a hearing with interpreters and a start time within 30 mins would cause a domain rule failure. The validation to check if an action was allowed did not take into account the hearing status. 