### PR TITLE
VIH-10361 Fix for unable to update judge last minute

### DIFF
--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -691,6 +691,23 @@ namespace BookingsApi.Client
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<JudiciaryParticipantResponse> UpdateJudiciaryParticipantAsync(System.Guid hearingId, string personalCode, UpdateJudiciaryParticipantRequest request, System.Threading.CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Replaces the judiciary participant judge on a hearing
+        /// </summary>
+        /// <param name="hearingId">The id of the hearing</param>
+        /// <param name="request">The new judiciary participant judge</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<JudiciaryParticipantResponse> ReassignJudiciaryJudgeAsync(System.Guid hearingId, ReassignJudiciaryJudgeRequest request);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Replaces the judiciary participant judge on a hearing
+        /// </summary>
+        /// <param name="hearingId">The id of the hearing</param>
+        /// <param name="request">The new judiciary participant judge</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<JudiciaryParticipantResponse> ReassignJudiciaryJudgeAsync(System.Guid hearingId, ReassignJudiciaryJudgeRequest request, System.Threading.CancellationToken cancellationToken);
+
         /// <exception cref="BookingsApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<BulkJudiciaryPersonResponse> BulkJudiciaryPersonsAsync(System.Collections.Generic.IEnumerable<JudiciaryPersonRequest> request);
 
@@ -5806,6 +5823,109 @@ namespace BookingsApi.Client
                                 throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new BookingsApiException<ValidationProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new BookingsApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Replaces the judiciary participant judge on a hearing
+        /// </summary>
+        /// <param name="hearingId">The id of the hearing</param>
+        /// <param name="request">The new judiciary participant judge</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<JudiciaryParticipantResponse> ReassignJudiciaryJudgeAsync(System.Guid hearingId, ReassignJudiciaryJudgeRequest request)
+        {
+            return ReassignJudiciaryJudgeAsync(hearingId, request, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Replaces the judiciary participant judge on a hearing
+        /// </summary>
+        /// <param name="hearingId">The id of the hearing</param>
+        /// <param name="request">The new judiciary participant judge</param>
+        /// <exception cref="BookingsApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<JudiciaryParticipantResponse> ReassignJudiciaryJudgeAsync(System.Guid hearingId, ReassignJudiciaryJudgeRequest request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (hearingId == null)
+                throw new System.ArgumentNullException("hearingId");
+
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/hearings/{hearingId}/joh/judge");
+            urlBuilder_.Replace("{hearingId}", System.Uri.EscapeDataString(ConvertToString(hearingId, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<string>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<JudiciaryParticipantResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
                         }
                         else
                         {

--- a/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
+++ b/BookingsApi/BookingsApi.Client/BookingsApiClient.cs
@@ -5928,6 +5928,26 @@ namespace BookingsApi.Client
                             return objectResponse_.Object;
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<string>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ValidationProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new BookingsApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new BookingsApiException<ValidationProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new BookingsApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);

--- a/BookingsApi/BookingsApi.Contract/V1/Requests/ReassignJudiciaryJudgeRequest.cs
+++ b/BookingsApi/BookingsApi.Contract/V1/Requests/ReassignJudiciaryJudgeRequest.cs
@@ -1,0 +1,15 @@
+namespace BookingsApi.Contract.V1.Requests
+{
+    public class ReassignJudiciaryJudgeRequest
+    {
+        /// <summary>
+        /// The participant's judicial personal code
+        /// </summary>
+        public string PersonalCode { get; set; }
+        
+        /// <summary>
+        /// The participant's display name
+        /// </summary>
+        public string DisplayName { get; set; }
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Commands/ReassignJudiciaryJudgeCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/ReassignJudiciaryJudgeCommand.cs
@@ -1,0 +1,55 @@
+using BookingsApi.DAL.Dtos;
+using BookingsApi.DAL.Services;
+using BookingsApi.Domain.JudiciaryParticipants;
+
+namespace BookingsApi.DAL.Commands
+{
+    public class ReassignJudiciaryJudgeCommand : ICommand
+    {
+        public Guid HearingId { get; }
+        public NewJudiciaryJudge NewJudiciaryJudge { get; }
+        
+        public ReassignJudiciaryJudgeCommand(Guid hearingId, NewJudiciaryJudge newJudiciaryJudge)
+        {
+            HearingId = hearingId;
+            NewJudiciaryJudge = newJudiciaryJudge;
+        }
+    }
+
+    public class ReassignJudiciaryJudgeCommandHandler : ICommandHandler<ReassignJudiciaryJudgeCommand>
+    {
+        private readonly BookingsDbContext _context;
+        
+        public ReassignJudiciaryJudgeCommandHandler(BookingsDbContext context)
+        {
+            _context = context;
+        }
+        
+        public async Task Handle(ReassignJudiciaryJudgeCommand command)
+        {
+            var hearing = await _context.VideoHearings
+                .Include(x => x.JudiciaryParticipants).ThenInclude(x => x.JudiciaryPerson)
+                .Include(x => x.Participants).ThenInclude(x => x.HearingRole.UserRole)
+                .SingleOrDefaultAsync(x => x.Id == command.HearingId);
+            
+            if (hearing == null)
+            {
+                throw new HearingNotFoundException(command.HearingId);
+            }
+            
+            var judiciaryPerson = await _context.JudiciaryPersons
+                .SingleOrDefaultAsync(x => x.PersonalCode == command.NewJudiciaryJudge.PersonalCode);
+            
+            if (judiciaryPerson == null)
+            {
+                throw new JudiciaryPersonNotFoundException(command.NewJudiciaryJudge.PersonalCode);
+            }
+            
+            var newJudge = new JudiciaryJudge(command.NewJudiciaryJudge.DisplayName, judiciaryPerson);
+            
+            hearing.ReassignJudiciaryJudge(newJudge);
+
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
@@ -51,9 +51,22 @@ namespace BookingsApi.DAL.Commands
             }
 
             _context.Update(hearing);
-            
+
             foreach (var removedParticipantId in command.RemovedParticipantIds)
+            {
+                var participant = hearing.GetParticipants().Single(x => x.Id == removedParticipantId);
+                
+                if (participant.HearingRole.IsJudge() && command.NewParticipants.Exists(x => x.HearingRole.IsJudge()))
+                {
+                    var newJudgeParticipant = command.NewParticipants.Single(x => x.HearingRole.IsJudge());
+                    _hearingService.ReassignJudge(hearing, newJudgeParticipant);
+
+                    command.NewParticipants.Remove(newJudgeParticipant);
+                    continue;
+                }
+                
                 hearing.RemoveParticipantById(removedParticipantId, false);
+            }
             
             await _hearingService.AddParticipantToService(hearing, command.NewParticipants);
             

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
@@ -59,7 +59,7 @@ namespace BookingsApi.DAL.Commands
                 if (participant.HearingRole.IsJudge() && command.NewParticipants.Exists(x => x.HearingRole.IsJudge()))
                 {
                     var newJudgeParticipant = command.NewParticipants.Single(x => x.HearingRole.IsJudge());
-                    _hearingService.ReassignJudge(hearing, newJudgeParticipant);
+                    await _hearingService.ReassignJudge(hearing, newJudgeParticipant);
 
                     command.NewParticipants.Remove(newJudgeParticipant);
                     continue;

--- a/BookingsApi/BookingsApi.DAL/Dtos/NewJudiciaryJudge.cs
+++ b/BookingsApi/BookingsApi.DAL/Dtos/NewJudiciaryJudge.cs
@@ -1,0 +1,8 @@
+namespace BookingsApi.DAL.Dtos
+{
+    public class NewJudiciaryJudge
+    {
+        public string DisplayName { get; set; }
+        public string PersonalCode { get; set; }
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
+++ b/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
@@ -42,7 +42,7 @@ namespace BookingsApi.DAL.Services
 
         Task AddJudiciaryParticipantToVideoHearing(VideoHearing videoHearing, NewJudiciaryParticipant participant);
 
-        void ReassignJudge(VideoHearing hearing, NewParticipant newJudgeParticipant);
+        Task ReassignJudge(VideoHearing hearing, NewParticipant newJudgeParticipant);
     }
     public class HearingService : IHearingService
     {
@@ -124,9 +124,10 @@ namespace BookingsApi.DAL.Services
             return participantList;
         }
 
-        public void ReassignJudge(VideoHearing hearing, NewParticipant newJudgeParticipant)
+        public async Task ReassignJudge(VideoHearing hearing, NewParticipant newJudgeParticipant)
         {
-            var judge = new Judge(newJudgeParticipant.Person, newJudgeParticipant.HearingRole, newJudgeParticipant.CaseRole);
+            var person = await _context.Persons.FirstAsync(x => x.ContactEmail == newJudgeParticipant.Person.ContactEmail);
+            var judge = new Judge(person, newJudgeParticipant.HearingRole, newJudgeParticipant.CaseRole);
             hearing.ReassignJudge(judge);
         }
 

--- a/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
+++ b/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
@@ -41,6 +41,8 @@ namespace BookingsApi.DAL.Services
         Task RemoveParticipantLinks(List<Participant> participants, Participant participant);
 
         Task AddJudiciaryParticipantToVideoHearing(VideoHearing videoHearing, NewJudiciaryParticipant participant);
+
+        void ReassignJudge(VideoHearing hearing, NewParticipant newJudgeParticipant);
     }
     public class HearingService : IHearingService
     {
@@ -120,6 +122,12 @@ namespace BookingsApi.DAL.Services
             }
             await LoadHearingRoles(participantList);
             return participantList;
+        }
+
+        public void ReassignJudge(VideoHearing hearing, NewParticipant newJudgeParticipant)
+        {
+            var judge = new Judge(newJudgeParticipant.Person, newJudgeParticipant.HearingRole, newJudgeParticipant.CaseRole);
+            hearing.ReassignJudge(judge);
         }
 
         private async Task LoadHearingRoles(List<Participant> participantList)

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -736,6 +736,19 @@ namespace BookingsApi.Domain
                 };
         }
 
+        public void ReassignJudge(Judge newJudge)
+        {
+            var existingJudge = Participants.FirstOrDefault(p => p is Judge);
+            if (existingJudge != null)
+            {
+                Participants.Remove(existingJudge);
+            }
+            
+            Participants.Add(newJudge);
+            
+            UpdatedDate = DateTime.UtcNow;
+        }
+
         private bool IsHearingConfirmedAndCloseToStartTime() => ScheduledDateTime.AddMinutes(-30) <= DateTime.UtcNow &&
                                                                 (Status == BookingStatus.Created ||
                                                                  Status == BookingStatus.ConfirmedWithoutJudge);

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BookingsApi.Domain.Configuration;
 using BookingsApi.Domain.Ddd;
 using BookingsApi.Domain.Enumerations;
+using BookingsApi.Domain.JudiciaryParticipants;
 using BookingsApi.Domain.Participants;
 using BookingsApi.Domain.RefData;
 using BookingsApi.Domain.Validations;
@@ -745,6 +746,19 @@ namespace BookingsApi.Domain
             }
             
             Participants.Add(newJudge);
+            
+            UpdatedDate = DateTime.UtcNow;
+        }
+
+        public void ReassignJudiciaryJudge(JudiciaryJudge newJudge)
+        {
+            var existingJudge = JudiciaryParticipants.FirstOrDefault(p => p.HearingRoleCode == JudiciaryParticipantHearingRoleCode.Judge);
+            if (existingJudge != null)
+            {
+                JudiciaryParticipants.Remove(existingJudge);
+            }
+
+            JudiciaryParticipants.Add(newJudge);
             
             UpdatedDate = DateTime.UtcNow;
         }

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -671,8 +671,6 @@ namespace BookingsApi.Domain
                 throw new DomainRuleException("Hearing", errorMessage ?? DomainRuleErrorMessages.DefaultCannotEditAHearingCloseToStartTime);
             }
         }
-        
-        
 
         public void UpdateStatus(BookingStatus newStatus, string updatedBy, string cancelReason)
         {
@@ -739,6 +737,8 @@ namespace BookingsApi.Domain
 
         public void ReassignJudge(Judge newJudge)
         {
+            ValidateReassignJudgeAllowed();
+            
             var existingJudge = Participants.FirstOrDefault(p => p is Judge);
             if (existingJudge != null)
             {
@@ -752,6 +752,8 @@ namespace BookingsApi.Domain
 
         public void ReassignJudiciaryJudge(JudiciaryJudge newJudge)
         {
+            ValidateReassignJudgeAllowed();
+            
             var existingJudge = JudiciaryParticipants.FirstOrDefault(p => p.HearingRoleCode == JudiciaryParticipantHearingRoleCode.Judge);
             if (existingJudge != null)
             {
@@ -761,6 +763,14 @@ namespace BookingsApi.Domain
             JudiciaryParticipants.Add(newJudge);
             
             UpdatedDate = DateTime.UtcNow;
+        }
+        
+        private void ValidateReassignJudgeAllowed()
+        {
+            if (Status == BookingStatus.Cancelled)
+            {
+                throw new DomainRuleException("Hearing", DomainRuleErrorMessages.CannotEditACancelledHearing);
+            }
         }
 
         private bool IsHearingConfirmedAndCloseToStartTime() => ScheduledDateTime.AddMinutes(-30) <= DateTime.UtcNow &&

--- a/BookingsApi/BookingsApi.Domain/JudiciaryParticipants/JudiciaryJudge.cs
+++ b/BookingsApi/BookingsApi.Domain/JudiciaryParticipants/JudiciaryJudge.cs
@@ -1,0 +1,12 @@
+using BookingsApi.Domain.Enumerations;
+
+namespace BookingsApi.Domain.JudiciaryParticipants
+{
+    public class JudiciaryJudge : JudiciaryParticipant
+    {
+        public JudiciaryJudge(string displayName, JudiciaryPerson judiciaryPerson) 
+            : base(displayName, judiciaryPerson, JudiciaryParticipantHearingRoleCode.Judge)
+        {
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.Domain/Validations/DomainRuleErrorMessages.cs
+++ b/BookingsApi/BookingsApi.Domain/Validations/DomainRuleErrorMessages.cs
@@ -23,4 +23,6 @@ public static class DomainRuleErrorMessages
     public const string CannotAddInterpreterToHearingCloseToStartTime = "Cannot add an interpreter to a hearing close to the scheduled start time";
     public const string FirstNameRequired = "FirstName cannot be empty";
     public const string LastNameRequired = "LastName cannot be empty";
+    public const string CannotAddJudgeWhenJudiciaryJudgeAlreadyExists = "Cannot add judge when judiciary judge already exists";
+    public const string CannotAddJudiciaryJudgeWhenJudgeAlreadyExists = "Cannot add judiciary judge when non-judiciary judge already exists";
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/ReassignJudiciaryJudgeTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/ReassignJudiciaryJudgeTests.cs
@@ -1,0 +1,203 @@
+using BookingsApi.Contract.V1.Requests;
+using BookingsApi.Contract.V1.Responses;
+using BookingsApi.DAL.Queries;
+using BookingsApi.Domain.Enumerations;
+using BookingsApi.Mappings.Common;
+using BookingsApi.Validations.V1;
+
+namespace BookingsApi.IntegrationTests.Api.V1.JudiciaryParticipants
+{
+    public class ReassignJudiciaryJudgeTests : ApiTest
+    {
+        [Test]
+        public async Task Should_reassign_judiciary_judge_when_hearing_has_a_judge()
+        {
+            // Arrange
+            var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
+            {
+                options.AddJudge = true;
+            }, status: BookingStatus.Created);
+            var personalCodeNewJudge = Guid.NewGuid().ToString();
+            await Hooks.AddJudiciaryPerson(personalCode: personalCodeNewJudge);
+
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCodeNewJudge
+            };
+            
+            // Act
+            using var client = Application.CreateClient();
+            var result = await client.PutAsync(
+                ApiUriFactory.JudiciaryParticipantEndpoints.ReassignJudiciaryJudge(seededHearing.Id), 
+                RequestBody.Set(request));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeTrue();
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+            
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var hearing = await new GetHearingByIdQueryHandler(db).Handle(new GetHearingByIdQuery(seededHearing.Id));
+            var judiciaryParticipant = hearing.JudiciaryParticipants.FirstOrDefault(x => x.JudiciaryPerson.PersonalCode == personalCodeNewJudge);
+            judiciaryParticipant.Should().NotBeNull();
+            
+            var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
+            response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
+            
+            // TODO assert on events published
+        }
+
+        [Test]
+        public async Task Should_reassign_judiciary_judge_when_hearing_does_not_have_a_judge()
+        {
+            // Arrange
+            var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
+            {
+                options.AddJudge = false;
+            }, status: BookingStatus.Created);
+            var personalCodeNewJudge = Guid.NewGuid().ToString();
+            await Hooks.AddJudiciaryPerson(personalCode: personalCodeNewJudge);
+
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCodeNewJudge
+            };
+            
+            // Act
+            using var client = Application.CreateClient();
+            var result = await client.PutAsync(
+                ApiUriFactory.JudiciaryParticipantEndpoints.ReassignJudiciaryJudge(seededHearing.Id), 
+                RequestBody.Set(request));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeTrue();
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+            
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var hearing = await new GetHearingByIdQueryHandler(db).Handle(new GetHearingByIdQuery(seededHearing.Id));
+            var judiciaryParticipant = hearing.JudiciaryParticipants.FirstOrDefault(x => x.JudiciaryPerson.PersonalCode == personalCodeNewJudge);
+            judiciaryParticipant.Should().NotBeNull();
+            
+            var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
+            response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
+            
+            // TODO assert on events published
+        }
+
+        [Test]
+        public async Task Should_reassign_judiciary_judge_when_new_judge_is_same_as_old_judge()
+        {
+            // Arrange
+            var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
+            {
+                options.AddJudge = true;
+            }, status: BookingStatus.Created);
+            var oldJudge = ((JudiciaryParticipant)seededHearing.GetJudge());
+            var personalCodeNewJudge = oldJudge.JudiciaryPerson.PersonalCode;
+
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCodeNewJudge
+            };
+            
+            // Act
+            using var client = Application.CreateClient();
+            var result = await client.PutAsync(
+                ApiUriFactory.JudiciaryParticipantEndpoints.ReassignJudiciaryJudge(seededHearing.Id), 
+                RequestBody.Set(request));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeTrue();
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+            
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var hearing = await new GetHearingByIdQueryHandler(db).Handle(new GetHearingByIdQuery(seededHearing.Id));
+            var judiciaryParticipant = hearing.JudiciaryParticipants.FirstOrDefault(x => x.JudiciaryPerson.PersonalCode == personalCodeNewJudge);
+            judiciaryParticipant.Should().NotBeNull();
+            
+            var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
+            response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
+            
+            // TODO assert on events published
+        }
+
+        [Test]
+        public async Task Should_return_not_found_when_hearing_does_not_exist()
+        {
+            // Arrange
+            var hearingId = Guid.NewGuid();
+            var personalCodeNewJudge = Guid.NewGuid().ToString();
+            await Hooks.AddJudiciaryPerson(personalCode: Guid.NewGuid().ToString());
+            
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCodeNewJudge
+            };
+
+            // Act
+            using var client = Application.CreateClient();
+            var result = await client.PutAsync(
+                ApiUriFactory.JudiciaryParticipantEndpoints.ReassignJudiciaryJudge(hearingId), 
+                RequestBody.Set(request));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeFalse();
+            result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            var response = await ApiClientResponse.GetResponses<string>(result.Content);
+            response.Should().Be($"Hearing {hearingId} does not exist");
+        }
+
+        [Test]
+        public async Task Should_return_not_found_when_judiciary_person_does_not_exist()
+        {
+            // Arrange
+            var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
+            {
+                options.AddJudge = true;
+            });
+            var personalCodeNewJudge = Guid.NewGuid().ToString();
+
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCodeNewJudge
+            };
+
+            // Act
+            using var client = Application.CreateClient();
+            var result = await client.PutAsync(
+                ApiUriFactory.JudiciaryParticipantEndpoints.ReassignJudiciaryJudge(seededHearing.Id), 
+                RequestBody.Set(request));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeFalse();
+            result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            var response = await ApiClientResponse.GetResponses<string>(result.Content);
+            response.Should().Be($"Judiciary Person with personal code: {personalCodeNewJudge} does not exist");
+        }
+
+        [Test]
+        public async Task Should_return_bad_request_when_request_is_invalid()
+        {
+            // Arrange
+            var hearingId = Guid.NewGuid();
+            var request = new ReassignJudiciaryJudgeRequest();
+            
+            // Act
+            using var client = Application.CreateClient();
+            var result = await client.PutAsync(
+                ApiUriFactory.JudiciaryParticipantEndpoints.ReassignJudiciaryJudge(hearingId), 
+                RequestBody.Set(request));
+            
+            // Assert
+            result.IsSuccessStatusCode.Should().BeFalse();
+            result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var validationProblemDetails = await ApiClientResponse.GetResponses<ValidationProblemDetails>(result.Content);
+            validationProblemDetails.Errors[nameof(request.DisplayName)][0].Should().Be(ReassignJudiciaryJudgeRequestValidation.NoDisplayNameErrorMessage);
+            validationProblemDetails.Errors[nameof(request.PersonalCode)][0].Should().Be(ReassignJudiciaryJudgeRequestValidation.NoPersonalCodeErrorMessage);
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/ReassignJudiciaryJudgeTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/ReassignJudiciaryJudgeTests.cs
@@ -43,8 +43,6 @@ namespace BookingsApi.IntegrationTests.Api.V1.JudiciaryParticipants
             
             var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
             response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
-            
-            // TODO assert on events published
         }
 
         [Test]
@@ -81,8 +79,6 @@ namespace BookingsApi.IntegrationTests.Api.V1.JudiciaryParticipants
             
             var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
             response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
-            
-            // TODO assert on events published
         }
 
         [Test]
@@ -119,8 +115,6 @@ namespace BookingsApi.IntegrationTests.Api.V1.JudiciaryParticipants
             
             var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
             response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
-            
-            // TODO assert on events published
         }
 
         [Test]

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/ReassignJudiciaryJudgeCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/ReassignJudiciaryJudgeCommandTests.cs
@@ -1,0 +1,113 @@
+using BookingsApi.DAL.Commands;
+using BookingsApi.DAL.Dtos;
+using BookingsApi.DAL.Exceptions;
+using BookingsApi.DAL.Queries;
+using BookingsApi.DAL.Services;
+using BookingsApi.Domain.Enumerations;
+using BookingsApi.Domain.JudiciaryParticipants;
+
+namespace BookingsApi.IntegrationTests.Database.Commands
+{
+    public class ReassignJudiciaryJudgeCommandTests : DatabaseTestsBase
+    {
+        private ReassignJudiciaryJudgeCommandHandler _commandHandler;
+        private GetHearingByIdQueryHandler _getHearingByIdQueryHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            var context = new BookingsDbContext(BookingsDbContextOptions);
+            _commandHandler = new ReassignJudiciaryJudgeCommandHandler(context);
+            _getHearingByIdQueryHandler = new GetHearingByIdQueryHandler(context);
+        }
+
+        [Test]
+        public async Task Should_reassign_judiciary_judge_when_hearing_has_a_judge()
+        {
+            var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
+            {
+                options.AddJudge = true;
+            }, status: BookingStatus.Created);
+            var personalCode = Guid.NewGuid().ToString();
+            await Hooks.AddJudiciaryPerson(personalCode: personalCode);
+            var hearingId = seededHearing.Id;
+            var newJudiciaryJudge = new NewJudiciaryJudge
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCode
+            };
+            var command = new ReassignJudiciaryJudgeCommand(hearingId, newJudiciaryJudge);
+
+            await _commandHandler.Handle(command);
+            
+            var updatedHearing =
+                await _getHearingByIdQueryHandler.Handle(new GetHearingByIdQuery(seededHearing.Id));
+            var newAssignedJudge = (JudiciaryParticipant)updatedHearing.GetJudge();
+            newAssignedJudge.Should().NotBeNull();
+            newAssignedJudge.JudiciaryPerson.PersonalCode.Should().Be(personalCode);
+        }
+
+        [Test]
+        public async Task Should_reassign_judiciary_judge_when_hearing_does_not_have_a_judge()
+        {
+            var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
+            {
+                options.AddJudge = false;
+            }, status: BookingStatus.Created);
+            var personalCode = Guid.NewGuid().ToString();
+            await Hooks.AddJudiciaryPerson(personalCode: personalCode);
+            var hearingId = seededHearing.Id;
+            var newJudiciaryJudge = new NewJudiciaryJudge
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCode
+            };
+            var command = new ReassignJudiciaryJudgeCommand(hearingId, newJudiciaryJudge);
+
+            await _commandHandler.Handle(command);
+            
+            var updatedHearing =
+                await _getHearingByIdQueryHandler.Handle(new GetHearingByIdQuery(seededHearing.Id));
+            var newAssignedJudge = (JudiciaryParticipant)updatedHearing.GetJudge();
+            newAssignedJudge.Should().NotBeNull();
+            newAssignedJudge.JudiciaryPerson.PersonalCode.Should().Be(personalCode);
+        }
+        
+        [Test]
+        public async Task Should_throw_exception_when_hearing_does_not_exist()
+        {
+            var personalCode = Guid.NewGuid().ToString();
+            await Hooks.AddJudiciaryPerson(personalCode: personalCode);
+            var hearingId = Guid.NewGuid();
+            var newJudiciaryJudge = new NewJudiciaryJudge
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCode
+            };
+
+            var command = new ReassignJudiciaryJudgeCommand(hearingId, newJudiciaryJudge);
+
+            Assert.ThrowsAsync<HearingNotFoundException>(() => _commandHandler.Handle(command));
+        }
+        
+        [Test]
+        public async Task Should_throw_exception_when_judiciary_person_does_not_exist()
+        {
+            var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
+            {
+                options.AddJudge = true;
+            }, status: BookingStatus.Created);
+            var personalCode = Guid.NewGuid().ToString();
+            var hearingId = seededHearing.Id;
+            var newJudiciaryJudge = new NewJudiciaryJudge
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = personalCode
+            };
+            
+            var command = new ReassignJudiciaryJudgeCommand(hearingId, newJudiciaryJudge);
+
+            Assert.ThrowsAsync<JudiciaryPersonNotFoundException>(() => _commandHandler.Handle(command));
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateHearingParticipantsCommandHandlerTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateHearingParticipantsCommandHandlerTests.cs
@@ -6,6 +6,7 @@ using BookingsApi.DAL.Services;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.Participants;
 using BookingsApi.Domain.RefData;
+using BookingsApi.Domain.Validations;
 using Testing.Common.Builders.Domain;
 
 namespace BookingsApi.IntegrationTests.Database.Commands
@@ -40,7 +41,7 @@ namespace BookingsApi.IntegrationTests.Database.Commands
 
             var hearingService = new HearingService(_context);
 
-            _hearing = await Hooks.SeedVideoHearing();
+            _hearing = await Hooks.SeedVideoHearing(status: BookingStatus.Created);
             TestContext.WriteLine($"New seeded video hearing id: {_hearing.Id}");
 
             _existingParticipants = new List<ExistingParticipantDetails>();
@@ -295,9 +296,101 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             addedJudge.Person.LastName.Should().Be(newJudge.LastName);
         }
 
+        [Test]
+        public async Task Should_change_judge_within_30_minutes_of_hearing_starting()
+        {
+            // Arrange
+            await UpdateHearingScheduledDateTime(DateTime.UtcNow.AddMinutes(15));
+
+            var judgeCaseRole = _genericCaseType.CaseRoles.First(x => x.Name == "Judge");
+            var judgeHearingRole =
+                judgeCaseRole.HearingRoles.First(x => x.Name == "Judge");
+
+            var oldJudge = _hearing.GetParticipants().Single(x => x.HearingRole.Id == judgeHearingRole.Id);
+            _personsToRemove.Add(oldJudge.Person.ContactEmail);
+            var oldJudgeId = oldJudge.Id;
+
+            var newJudge = new PersonBuilder(true).Build();
+
+            var newParticipant = new NewParticipant()
+            {
+                Person = newJudge,
+                CaseRole = judgeCaseRole,
+                HearingRole = judgeHearingRole,
+                DisplayName = $"{newJudge.FirstName} {newJudge.LastName}"
+            };
+
+            _removedParticipantIds.Add(oldJudgeId);
+            _newParticipants.Add(newParticipant);
+            _command = BuildCommand();
+            
+            // Act
+            await _handler.Handle(_command);
+            var updatedVideoHearing =
+                await _getHearingByIdQueryHandler.Handle(new GetHearingByIdQuery(_hearing.Id));
+            var addedJudge = updatedVideoHearing.GetParticipants().SingleOrDefault(x => x.HearingRole.Id == judgeHearingRole.Id);
+            
+            // Assert
+            addedJudge.Person.FirstName.Should().Be(newJudge.FirstName);
+            addedJudge.Person.LastName.Should().Be(newJudge.LastName);
+        }
+
+        [Test]
+        public async Task Should_not_be_able_to_remove_judge_within_30_minutes_of_hearing_starting()
+        {
+            // Arrange
+            await UpdateHearingScheduledDateTime(DateTime.UtcNow.AddMinutes(15));
+
+            var judgeCaseRole = _genericCaseType.CaseRoles.First(x => x.Name == "Judge");
+            var judgeHearingRole =
+                judgeCaseRole.HearingRoles.First(x => x.Name == "Judge");
+
+            var oldJudge = _hearing.GetParticipants().Single(x => x.HearingRole.Id == judgeHearingRole.Id);
+            _personsToRemove.Add(oldJudge.Person.ContactEmail);
+            var oldJudgeId = oldJudge.Id;
+
+            _removedParticipantIds.Add(oldJudgeId);
+            _newParticipants.Clear();
+            _command = BuildCommand();
+            
+            // Act & Assert
+            Assert.ThrowsAsync<DomainRuleException>(async () =>
+            {
+                await _handler.Handle(_command);
+            })!.Message.Should().Be(DomainRuleErrorMessages.CannotRemoveParticipantCloseToStartTime);
+        }
+        
+        [Test]
+        public async Task Should_not_be_able_to_remove_non_host_participant_within_30_minutes_of_hearing_starting()
+        {
+            // Arrange
+            await UpdateHearingScheduledDateTime(DateTime.UtcNow.AddMinutes(15));
+
+            var participantToRemove = _hearing.GetParticipants().First(x => x.Discriminator == "Individual");
+            _personsToRemove.Add(participantToRemove.Person.ContactEmail);
+            var participantToRemoveId = participantToRemove.Id;
+
+            _removedParticipantIds.Add(participantToRemoveId);
+            _newParticipants.Clear();
+            _command = BuildCommand();
+            
+            // Act & Assert
+            Assert.ThrowsAsync<DomainRuleException>(async () =>
+            {
+                await _handler.Handle(_command);
+            })!.Message.Should().Be(DomainRuleErrorMessages.CannotRemoveParticipantCloseToStartTime);
+        }
+
         private UpdateHearingParticipantsCommand BuildCommand()
         {
             return new UpdateHearingParticipantsCommand(_hearing.Id, _existingParticipants, _newParticipants, _removedParticipantIds, _linkedParticipants);
+        }
+
+        private async Task UpdateHearingScheduledDateTime(DateTime newScheduledDateTime)
+        {
+            var hearing = await _context.VideoHearings.FirstAsync(x => x.Id == _hearing.Id);
+            hearing.SetProtected(nameof(_hearing.ScheduledDateTime), newScheduledDateTime);
+            await _context.SaveChangesAsync();
         }
 
         [TearDown]

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateHearingParticipantsCommandHandlerTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateHearingParticipantsCommandHandlerTests.cs
@@ -272,6 +272,9 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var oldJudgeId = oldJudge.Id;
 
             var newJudge = new PersonBuilder(true).Build();
+            await _context.Persons.AddAsync(newJudge);
+            await _context.SaveChangesAsync();
+            _personsToRemove.Add(newJudge.ContactEmail);
 
             var newParticipant = new NewParticipant()
             {
@@ -311,6 +314,9 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var oldJudgeId = oldJudge.Id;
 
             var newJudge = new PersonBuilder(true).Build();
+            await _context.Persons.AddAsync(newJudge);
+            await _context.SaveChangesAsync();
+            _personsToRemove.Add(newJudge.ContactEmail);
 
             var newParticipant = new NewParticipant()
             {

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudgeTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudgeTests.cs
@@ -1,3 +1,6 @@
+using BookingsApi.Domain.Enumerations;
+using BookingsApi.Domain.Validations;
+
 namespace BookingsApi.UnitTests.Domain.Hearing
 {
     public class ReassignJudgeTests
@@ -28,6 +31,22 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             
             // Assert
             hearing.GetJudge().Should().Be(newJudge);
+        }
+
+        [Test]
+        public void should_throw_exception_when_reassigning_judge_to_cancelled_hearing()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().Build();
+            hearing.SetProtected(nameof(hearing.Status), BookingStatus.Cancelled);
+            var newJudge = new JudgeBuilder().Build();
+            
+            // Act
+            var action = () => hearing.ReassignJudge(newJudge);
+            
+            // Assert
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures
+                .Exists(x => x.Message == DomainRuleErrorMessages.CannotEditACancelledHearing).Should().BeTrue();
         }
     }
 }

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudgeTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudgeTests.cs
@@ -48,5 +48,35 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             action.Should().Throw<DomainRuleException>().And.ValidationFailures
                 .Exists(x => x.Message == DomainRuleErrorMessages.CannotEditACancelledHearing).Should().BeTrue();
         }
+
+        [Test]
+        public void should_throw_exception_when_reassigning_null_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().Build();
+            
+            // Act
+            var action = () => hearing.ReassignJudge(null);
+            
+            // Assert
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void should_throw_exception_when_adding_new_judge_to_hearing_with_judiciary_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false)
+                .WithJudiciaryJudge()
+                .Build();
+            var newJudge = new JudgeBuilder().Build();
+            
+            // Act
+            var action = () => hearing.ReassignJudge(newJudge);
+            
+            // Assert
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures
+                .Exists(x => x.Message == DomainRuleErrorMessages.CannotAddJudgeWhenJudiciaryJudgeAlreadyExists).Should().BeTrue();
+        }
     }
 }

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudgeTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudgeTests.cs
@@ -1,0 +1,33 @@
+namespace BookingsApi.UnitTests.Domain.Hearing
+{
+    public class ReassignJudgeTests
+    {
+        [Test]
+        public void should_reassign_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().Build();
+            var newJudge = new JudgeBuilder().Build();
+
+            // Act
+            hearing.ReassignJudge(newJudge);
+            
+            // Assert
+            hearing.GetJudge().Should().Be(newJudge);
+        }
+
+        [Test]
+        public void should_reassign_judge_to_hearing_without_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false).Build();
+            var newJudge = new JudgeBuilder().Build();
+            
+            // Act
+            hearing.ReassignJudge(newJudge);
+            
+            // Assert
+            hearing.GetJudge().Should().Be(newJudge);
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
@@ -1,4 +1,6 @@
+using BookingsApi.Contract.V1.Enums;
 using BookingsApi.Domain.JudiciaryParticipants;
+using BookingsApi.Domain.Validations;
 
 namespace BookingsApi.UnitTests.Domain.Hearing
 {
@@ -34,6 +36,22 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             
             // Assert
             hearing.GetJudge().Should().Be(newJudiciaryJudge);
+        }
+        
+        [Test]
+        public void should_throw_exception_when_reassigning_judiciary_judge_to_cancelled_hearing()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().Build();
+            hearing.SetProtected(nameof(hearing.Status), BookingStatus.Cancelled);
+            var newJudge = new JudgeBuilder().Build();
+            
+            // Act
+            var action = () => hearing.ReassignJudge(newJudge);
+            
+            // Assert
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures
+                .Exists(x => x.Message == DomainRuleErrorMessages.CannotEditACancelledHearing).Should().BeTrue();
         }
     }
 }

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
@@ -1,4 +1,5 @@
 using BookingsApi.Contract.V1.Enums;
+using BookingsApi.Domain;
 using BookingsApi.Domain.JudiciaryParticipants;
 using BookingsApi.Domain.Validations;
 
@@ -52,6 +53,92 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             // Assert
             action.Should().Throw<DomainRuleException>().And.ValidationFailures
                 .Exists(x => x.Message == DomainRuleErrorMessages.CannotEditACancelledHearing).Should().BeTrue();
+        }
+        
+        [Test]
+        public void should_throw_exception_when_reassigning_null_judiciary_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().Build();
+            
+            // Act
+            var action = () => hearing.ReassignJudiciaryJudge(null);
+            
+            // Assert
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void should_throw_exception_when_adding_new_judiciary_judge_to_hearing_with_non_judiciary_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: true).Build();
+            var newJudiciaryPerson = new JudiciaryPersonBuilder().Build();
+            var newJudiciaryJudge = new JudiciaryJudge("DisplayName", newJudiciaryPerson);
+            
+            // Act
+            var action = () => hearing.ReassignJudiciaryJudge(newJudiciaryJudge);
+            
+            // Assert
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures
+                .Exists(x => x.Message == DomainRuleErrorMessages.CannotAddJudiciaryJudgeWhenJudgeAlreadyExists).Should().BeTrue();
+        }
+
+        [TestCase(true, true)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        public void should_throw_exception_when_judiciary_person_is_a_leaver(bool hasLeft, bool leaver)
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false).Build();
+            var newJudiciaryPerson = new JudiciaryPersonBuilder().Build();
+            newJudiciaryPerson.HasLeft = hasLeft;
+            newJudiciaryPerson.Leaver = leaver;
+            newJudiciaryPerson.LeftOn = DateTime.UtcNow.AddYears(-1).ToShortDateString();
+            var newJudiciaryJudge = new JudiciaryJudge("DisplayName", newJudiciaryPerson);
+            
+            // Act
+            var action = () => hearing.ReassignJudiciaryJudge(newJudiciaryJudge);
+            
+            // Assert
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures
+                .Exists(x => x.Message == "Cannot add a participant who is a leaver").Should().BeTrue();
+        }
+
+        [Test]
+        public void should_throw_exception_when_judiciary_person_already_exists_on_hearing_with_different_role()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false)
+                .WithJudiciaryJudge()
+                .Build();
+            var newJudiciaryPerson = new JudiciaryPersonBuilder().Build();
+            hearing.AddJudiciaryPanelMember(newJudiciaryPerson, "PanelMemberDisplayName");
+            var newJudiciaryJudge = new JudiciaryJudge("DisplayName", newJudiciaryPerson);
+            
+            // Act
+            var action = () => hearing.ReassignJudiciaryJudge(newJudiciaryJudge);
+            
+            // Assert
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures
+                .Exists(x => x.Message == DomainRuleErrorMessages.JudiciaryPersonAlreadyExists(newJudiciaryPerson.PersonalCode)).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_reassign_same_judiciary_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false)
+                .WithJudiciaryJudge()
+                .Build();
+            var judiciaryPerson = ((JudiciaryParticipant)hearing.GetJudge()).JudiciaryPerson;
+            var judiciaryJudge = new JudiciaryJudge("DisplayName", judiciaryPerson);
+            
+            // Act
+            hearing.ReassignJudiciaryJudge(judiciaryJudge);
+            
+            // Assert
+            hearing.GetJudge().Should().Be(judiciaryJudge);
         }
     }
 }

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
@@ -1,0 +1,39 @@
+using BookingsApi.Domain.JudiciaryParticipants;
+
+namespace BookingsApi.UnitTests.Domain.Hearing
+{
+    public class ReassignJudiciaryJudgeTests
+    {
+        [Test]
+        public void should_reassign_judiciary_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false)
+                .WithJudiciaryJudge()
+                .Build();
+            var newJudiciaryPerson = new JudiciaryPersonBuilder().Build();
+            var newJudiciaryJudge = new JudiciaryJudge("DisplayName", newJudiciaryPerson);
+
+            // Act
+            hearing.ReassignJudiciaryJudge(newJudiciaryJudge);
+            
+            // Assert
+            hearing.GetJudge().Should().Be(newJudiciaryJudge);
+        }
+
+        [Test]
+        public void should_reassign_judiciary_judge_to_hearing_without_judge()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false).Build();
+            var newJudiciaryPerson = new JudiciaryPersonBuilder().Build();
+            var newJudiciaryJudge = new JudiciaryJudge("DisplayName", newJudiciaryPerson);
+            
+            // Act
+            hearing.ReassignJudiciaryJudge(newJudiciaryJudge);
+            
+            // Assert
+            hearing.GetJudge().Should().Be(newJudiciaryJudge);
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.UnitTests/Validation/V1/ReassignJudiciaryJudgeRequestValidationTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Validation/V1/ReassignJudiciaryJudgeRequestValidationTests.cs
@@ -1,0 +1,62 @@
+using BookingsApi.Contract.V1.Requests;
+using BookingsApi.Validations.V1;
+
+namespace BookingsApi.UnitTests.Validation.V1
+{
+    public class ReassignJudiciaryJudgeRequestValidationTests
+    {
+        private ReassignJudiciaryJudgeRequestValidation _validator;
+        
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _validator = new ReassignJudiciaryJudgeRequestValidation();
+        }
+        
+        [Test]
+        public async Task Should_pass_validation()
+        {
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                DisplayName = "DisplayName",
+                PersonalCode = "PersonalCode"
+            };
+
+            var result = await _validator.ValidateAsync(request);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Should_return_missing_display_name_error()
+        {
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                PersonalCode = "PersonalCode"
+            };
+
+            var result = await _validator.ValidateAsync(request);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Count.Should().Be(1);
+            result.Errors.Exists(x => x.ErrorMessage == JudiciaryParticipantRequestValidation.NoDisplayNameErrorMessage)
+                .Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Should_return_missing_personal_code_error()
+        {
+            var request = new ReassignJudiciaryJudgeRequest
+            {
+                DisplayName = "DisplayName"
+            };
+
+            var result = await _validator.ValidateAsync(request);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Count.Should().Be(1);
+            result.Errors.Exists(x => x.ErrorMessage == JudiciaryParticipantRequestValidation.NoPersonalCodeErrorMessage)
+                .Should().BeTrue();
+        }
+    }
+}

--- a/BookingsApi/BookingsApi/Controllers/V1/JudiciaryParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/V1/JudiciaryParticipantsController.cs
@@ -182,6 +182,8 @@ namespace BookingsApi.Controllers.V1
         [HttpPut("{hearingId}/joh/judge")]
         [OpenApiOperation("ReassignJudiciaryJudge")]
         [ProducesResponseType(typeof(JudiciaryParticipantResponse), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> ReassignJudiciaryJudge(Guid hearingId, [FromBody] ReassignJudiciaryJudgeRequest request)
         {
             var validation = await new ReassignJudiciaryJudgeRequestValidation().ValidateAsync(request);

--- a/BookingsApi/BookingsApi/Controllers/V1/JudiciaryParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/V1/JudiciaryParticipantsController.cs
@@ -1,5 +1,6 @@
 using BookingsApi.Contract.V1.Requests;
 using BookingsApi.Contract.V1.Responses;
+using BookingsApi.Domain.JudiciaryParticipants;
 using BookingsApi.Mappings.Common;
 using BookingsApi.Mappings.V1;
 using BookingsApi.Validations.V1;
@@ -69,7 +70,7 @@ namespace BookingsApi.Controllers.V1
             }
             
             var hearing = await _queryHandler.Handle<GetHearingByIdQuery, VideoHearing>(new GetHearingByIdQuery(hearingId));
-            await _hearingParticipantService.PublishEventForNewJudiciaryParticipantsAsync(hearing, participants);
+            await PublishEventsForJudiciaryParticipantsAdded(hearing, participants);
 
             var addedParticipants = hearing.JudiciaryParticipants
                 .Where(x => request.Select(p => p.PersonalCode).Contains(x.JudiciaryPerson.PersonalCode));
@@ -113,11 +114,7 @@ namespace BookingsApi.Controllers.V1
             // ONLY publish this event when Hearing is set for ready for video
             var videoHearing =
                 await _queryHandler.Handle<GetHearingByIdQuery, VideoHearing>(new GetHearingByIdQuery(hearingId));
-            if (videoHearing.Status is BookingStatus.Created or BookingStatus.ConfirmedWithoutJudge)
-            {
-                await _eventPublisher.PublishAsync(
-                    new ParticipantRemovedIntegrationEvent(hearingId, command.RemovedParticipantId.Value));
-            }
+            await PublishEventForJudiciaryParticipantRemoved(videoHearing, command.RemovedParticipantId.Value);
 
             return NoContent();
         }
@@ -175,6 +172,102 @@ namespace BookingsApi.Controllers.V1
             var response = mapper.MapJudiciaryParticipantToResponse(updatedParticipant);
             
             return Ok(response);
+        }
+
+        /// <summary>
+        /// Replaces the judiciary participant judge on a hearing 
+        /// </summary>
+        /// <param name="hearingId">The id of the hearing</param>
+        /// <param name="request">The new judiciary participant judge</param>
+        [HttpPut("{hearingId}/joh/judge")]
+        [OpenApiOperation("ReassignJudiciaryJudge")]
+        [ProducesResponseType(typeof(JudiciaryParticipantResponse), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> ReassignJudiciaryJudge(Guid hearingId, [FromBody] ReassignJudiciaryJudgeRequest request)
+        {
+            var validation = await new ReassignJudiciaryJudgeRequestValidation().ValidateAsync(request);
+            if (!validation.IsValid)
+            {
+                ModelState.AddFluentValidationErrors(validation.Errors);
+                return ValidationProblem(ModelState);
+            }
+            
+            var newJudiciaryJudge = new NewJudiciaryJudge
+            {
+                DisplayName = request.DisplayName,
+                PersonalCode = request.PersonalCode
+            };
+            
+            var hearing = await _queryHandler.Handle<GetHearingByIdQuery, VideoHearing>(new GetHearingByIdQuery(hearingId));
+
+            if (hearing == null)
+            {
+                return NotFound(new HearingNotFoundException(hearingId).Message);
+            }
+
+            var oldJudge = (JudiciaryParticipant)hearing.GetJudge();
+            
+            var command = new ReassignJudiciaryJudgeCommand(hearingId, newJudiciaryJudge);
+            
+            try
+            {
+                await _commandHandler.Handle(command);
+            }
+            catch (HearingNotFoundException exception)
+            {
+                return NotFound(exception.Message);
+            }
+            catch (JudiciaryPersonNotFoundException exception)
+            {
+                return NotFound(exception.Message);
+            }
+            
+            hearing = await _queryHandler.Handle<GetHearingByIdQuery, VideoHearing>(new GetHearingByIdQuery(hearingId));
+            
+            var newJudge = (JudiciaryParticipant)hearing.GetJudge();
+
+            await PublishEventsForJudiciaryJudgeReassigned(hearing, oldJudge?.Id, newJudge);
+            
+            var mapper = new JudiciaryParticipantToResponseMapper();
+            var response = mapper.MapJudiciaryParticipantToResponse(newJudge);
+            
+            return Ok(response);
+        }
+
+        private async Task PublishEventsForJudiciaryJudgeReassigned(Hearing hearing, Guid? oldJudgeId, JudiciaryParticipant newJudge)
+        {
+            if (oldJudgeId == newJudge.Id)
+            {
+                return;
+            }
+            
+            if (oldJudgeId != null)
+            {
+                await PublishEventForJudiciaryParticipantRemoved(hearing, oldJudgeId.Value);
+            }
+            
+            await PublishEventsForJudiciaryParticipantsAdded(hearing, new List<NewJudiciaryParticipant>
+            {
+                new()
+                {
+                    DisplayName = newJudge.DisplayName,
+                    PersonalCode = newJudge.JudiciaryPerson.PersonalCode,
+                    HearingRoleCode = newJudge.HearingRoleCode
+                }
+            });
+        }
+        
+        private async Task PublishEventForJudiciaryParticipantRemoved(Hearing hearing, Guid removedJudiciaryParticipantId)
+        {
+            if (hearing.Status is BookingStatus.Created or BookingStatus.ConfirmedWithoutJudge)
+            {
+                await _eventPublisher.PublishAsync(
+                    new ParticipantRemovedIntegrationEvent(hearing.Id, removedJudiciaryParticipantId));
+            }
+        }
+
+        private async Task PublishEventsForJudiciaryParticipantsAdded(Hearing hearing, IEnumerable<NewJudiciaryParticipant> participants)
+        {
+            await _hearingParticipantService.PublishEventForNewJudiciaryParticipantsAsync(hearing, participants);
         }
     }
 }

--- a/BookingsApi/BookingsApi/Validations/V1/ReassignJudiciaryJudgeRequestValidation.cs
+++ b/BookingsApi/BookingsApi/Validations/V1/ReassignJudiciaryJudgeRequestValidation.cs
@@ -1,0 +1,17 @@
+using BookingsApi.Contract.V1.Requests;
+using FluentValidation;
+
+namespace BookingsApi.Validations.V1
+{
+    public class ReassignJudiciaryJudgeRequestValidation : AbstractValidator<ReassignJudiciaryJudgeRequest>
+    {
+        public const string NoPersonalCodeErrorMessage = "Personal code is required";
+        public const string NoDisplayNameErrorMessage = "Display name is required";
+
+        public ReassignJudiciaryJudgeRequestValidation()
+        {
+            RuleFor(x => x.PersonalCode).NotEmpty().WithMessage(NoPersonalCodeErrorMessage);
+            RuleFor(x => x.DisplayName).NotEmpty().WithMessage(NoDisplayNameErrorMessage);
+        }
+    }
+}

--- a/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
+++ b/BookingsApi/Testing.Common/Builders/Api/ApiUriFactory.cs
@@ -171,6 +171,7 @@ namespace Testing.Common.Builders.Api
             public static string AddJudiciaryParticipantsToHearing(Guid hearingId) => $"{ApiRoot}/{hearingId}/joh";
             public static string RemoveJudiciaryParticipantFromHearing(Guid hearingId, string personalCode) => $"{ApiRoot}/{hearingId}/joh/{personalCode}";
             public static string UpdateJudiciaryParticipant(Guid hearingId, string personalCode) => $"{ApiRoot}/{hearingId}/joh/{personalCode}";
+            public static string ReassignJudiciaryJudge(Guid hearingId) => $"{ApiRoot}/{hearingId}/joh/judge";
         }
 
         public static class StaffMemberEndpoints

--- a/BookingsApi/Testing.Common/Builders/Domain/JudgeBuilder.cs
+++ b/BookingsApi/Testing.Common/Builders/Domain/JudgeBuilder.cs
@@ -1,0 +1,29 @@
+using BookingsApi.Domain.Enumerations;
+using BookingsApi.Domain.Participants;
+using BookingsApi.Domain.RefData;
+
+namespace Testing.Common.Builders.Domain
+{
+    public class JudgeBuilder
+    {
+        private readonly Judge _judge;
+        
+        public JudgeBuilder()
+        {
+            var judgeCaseRole = new CaseRole(5, "Judge") { Group = CaseRoleGroup.Judge };
+            var judgeHearingRole = new HearingRole((int)HearingRoleIds.Judge, "Judge") { UserRole = new UserRole(1, "Judge") };
+            var judgePerson = new PersonBuilder(true).Build();
+            _judge = new Judge(judgePerson, judgeHearingRole, judgeCaseRole)
+            {
+                DisplayName = $"{judgePerson.FirstName} {judgePerson.LastName}"
+            };
+            _judge.SetProtected(nameof(_judge.CaseRole), judgeCaseRole);
+            _judge.SetProtected(nameof(_judge.HearingRole), judgeHearingRole);
+        }
+        
+        public Judge Build()
+        {
+            return _judge;
+        }
+    }
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10361


### Change description ###
Due to new domain rules added to bookings api, the judge can no longer be changed by removing the participant and adding the new one.

As a solution to this, a new operation for reassigning the judge has been added (ReassignJudge for V1, ReassignJudiciaryJudge for V2). This is called to update the judge instead of removing and adding the participants.

In V1 the participant updates are coordinated from bookings API, but in V2 they are part of admin web, so a new API endpoint has been added for reassigning the judge which admin web can call as part of V2.