### PR TITLE
VIH-10357 Fix incorrect booking status booking without a judge

### DIFF
--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/HearingsControllerTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/HearingsControllerTests.cs
@@ -337,18 +337,21 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
             CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateHearingStatusCommand>()), Times.Once);
         }
 
-        [Test]
-        public async Task Should_change_hearing_status_to_confirmed_without_judge_when_request_is_created_and_hearing_status_is_booked_without_judge()
+        [TestCase(UpdateBookingStatus.Created, BookingStatus.BookedWithoutJudge, BookingStatus.ConfirmedWithoutJudge)]
+        public async Task Should_change_hearing_status_to_correct_value(
+            UpdateBookingStatus updateStatus, 
+            BookingStatus currentBookingStatus, 
+            BookingStatus expectedNewBookingStatus)
         {
             var request = new UpdateBookingStatusRequest
             {
                 UpdatedBy = "email@hmcts.net",
-                Status = UpdateBookingStatus.Created,
+                Status = updateStatus,
                 CancelReason = ""
             };
             
             var hearing = GetHearing("123");
-            hearing.SetProtected(nameof(hearing.Status), BookingStatus.BookedWithoutJudge);
+            hearing.SetProtected(nameof(hearing.Status), currentBookingStatus);
             QueryHandlerMock
                 .Setup(x => x.Handle<GetHearingByIdQuery, VideoHearing>(It.IsAny<GetHearingByIdQuery>()))
                 .ReturnsAsync(hearing);
@@ -363,7 +366,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
 
             CommandHandlerMock.Verify(c => c.Handle(
                 It.Is<UpdateHearingStatusCommand>(x => 
-                    x.Status == BookingStatus.ConfirmedWithoutJudge)),
+                    x.Status == expectedNewBookingStatus)),
                 Times.Once);
         }
 

--- a/BookingsApi/BookingsApi/Controllers/V1/HearingsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/V1/HearingsController.cs
@@ -529,7 +529,7 @@ namespace BookingsApi.Controllers.V1
             
             try
             {
-                var bookingStatus = Enum.Parse<BookingStatus>(request.Status.ToString());
+                var bookingStatus = UpdateBookingStatusToBookingStatusMapper.Map(request.Status, videoHearing);
                 if (videoHearing.Status != bookingStatus)
                 {
                     await UpdateStatus(videoHearing, request.UpdatedBy, request.CancelReason, bookingStatus);

--- a/BookingsApi/BookingsApi/Mappings/V1/UpdateBookingStatusToBookingStatusMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V1/UpdateBookingStatusToBookingStatusMapper.cs
@@ -1,0 +1,20 @@
+using BookingsApi.Contract.V1.Requests.Enums;
+
+namespace BookingsApi.Mappings.V1
+{
+    public static class UpdateBookingStatusToBookingStatusMapper
+    {
+        public static BookingStatus Map(UpdateBookingStatus updateBookingStatus, VideoHearing videoHearing)
+        {
+            var bookingStatus = Enum.Parse<BookingStatus>(updateBookingStatus.ToString());
+            
+            if (videoHearing.Status == BookingStatus.BookedWithoutJudge && 
+                bookingStatus == BookingStatus.Created)
+            {
+                bookingStatus = BookingStatus.ConfirmedWithoutJudge;
+            }
+            
+            return bookingStatus;
+        }
+    }
+}

--- a/charts/vh-bookings-api/values.dev.template.yaml
+++ b/charts/vh-bookings-api/values.dev.template.yaml
@@ -4,4 +4,4 @@ java:
   ingressHost: ${SERVICE_FQDN}
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    SERVICEBUSQUEUE__QUEUENAME: oliver-booking
+    SERVICEBUSQUEUE__QUEUENAME: booking

--- a/charts/vh-bookings-api/values.dev.template.yaml
+++ b/charts/vh-bookings-api/values.dev.template.yaml
@@ -4,4 +4,4 @@ java:
   ingressHost: ${SERVICE_FQDN}
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    SERVICEBUSQUEUE__QUEUENAME: booking
+    SERVICEBUSQUEUE__QUEUENAME: oliver-booking


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10357


### Change description ###
When the hearing is successfully created and the booking status is BookedWithoutJudge, it should be changed to ConfirmedWithoutJudge, not Created, so that the No Judge Assigned label appears in the UI.

There is a separate ticket in the backlog to refactor the endpoint so that the status transition is set by the domain rather than the api caller. The change in this PR is an intermediary solution until then.
