### PR TITLE
VIH-10380 Booking status not updating after adding judge with V2 on

### DIFF
--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -812,6 +812,7 @@ namespace BookingsApi.Domain
             JudiciaryParticipants.Add(newJudge);
             
             UpdatedDate = DateTime.UtcNow;
+            UpdateBookingStatusJudgeRequirement();
         }
         
         private void ValidateReassignJudgeAllowed()

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/ReassignJudiciaryJudgeTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/ReassignJudiciaryJudgeTests.cs
@@ -43,6 +43,8 @@ namespace BookingsApi.IntegrationTests.Api.V1.JudiciaryParticipants
             
             var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
             response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
+            
+            hearing.Status.Should().Be(BookingStatus.Created);
         }
 
         [Test]
@@ -52,7 +54,7 @@ namespace BookingsApi.IntegrationTests.Api.V1.JudiciaryParticipants
             var seededHearing = await Hooks.SeedVideoHearingV2(configureOptions: options =>
             {
                 options.AddJudge = false;
-            }, status: BookingStatus.Created);
+            }, status: BookingStatus.ConfirmedWithoutJudge);
             var personalCodeNewJudge = Guid.NewGuid().ToString();
             await Hooks.AddJudiciaryPerson(personalCode: personalCodeNewJudge);
 
@@ -79,6 +81,8 @@ namespace BookingsApi.IntegrationTests.Api.V1.JudiciaryParticipants
             
             var response = await ApiClientResponse.GetResponses<JudiciaryParticipantResponse>(result.Content);
             response.Should().BeEquivalentTo(new JudiciaryParticipantToResponseMapper().MapJudiciaryParticipantToResponse(judiciaryParticipant));
+
+            hearing.Status.Should().Be(BookingStatus.Created);
         }
 
         [Test]

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/ReassignJudiciaryJudgeTests.cs
@@ -1,7 +1,7 @@
-using BookingsApi.Contract.V1.Enums;
 using BookingsApi.Domain;
 using BookingsApi.Domain.JudiciaryParticipants;
 using BookingsApi.Domain.Validations;
+using BookingStatus = BookingsApi.Domain.Enumerations.BookingStatus;
 
 namespace BookingsApi.UnitTests.Domain.Hearing
 {
@@ -14,6 +14,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             var hearing = new VideoHearingBuilder(addJudge: false)
                 .WithJudiciaryJudge()
                 .Build();
+            hearing.SetProtected(nameof(hearing.Status), BookingStatus.Created);
             var newJudiciaryPerson = new JudiciaryPersonBuilder().Build();
             var newJudiciaryJudge = new JudiciaryJudge("DisplayName", newJudiciaryPerson);
 
@@ -22,6 +23,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             
             // Assert
             hearing.GetJudge().Should().Be(newJudiciaryJudge);
+            hearing.Status.Should().Be(BookingStatus.Created);
         }
 
         [Test]
@@ -29,6 +31,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
         {
             // Arrange
             var hearing = new VideoHearingBuilder(addJudge: false).Build();
+            hearing.SetProtected(nameof(hearing.Status), BookingStatus.ConfirmedWithoutJudge);
             var newJudiciaryPerson = new JudiciaryPersonBuilder().Build();
             var newJudiciaryJudge = new JudiciaryJudge("DisplayName", newJudiciaryPerson);
             
@@ -37,6 +40,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             
             // Assert
             hearing.GetJudge().Should().Be(newJudiciaryJudge);
+            hearing.Status.Should().Be(BookingStatus.Created);
         }
         
         [Test]


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10380


### Change description ###
Fixes an issue where if you book a V2 hearing without a judge, then edit and add a judge, the booking status remains ConfirmedWithoutJudge, instead of changing to Created
