### PR TITLE
VIH-10414 Updated UpdateHearingParticipantsCommand NewParticipant list to be a list of values rather than reference

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
@@ -11,7 +11,7 @@ namespace BookingsApi.DAL.Commands
         {
             HearingId = hearingId;
             ExistingParticipants = existingParticipants;
-            NewParticipants = newParticipants;
+            NewParticipants = new List<NewParticipant>(newParticipants);
             RemovedParticipantIds = removedParticipantIds;
             LinkedParticipants = linkedParticipants ?? new List<LinkedParticipantDto>();
         }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/HearingParticipants/UpdateHearingParticipantsTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/HearingParticipants/UpdateHearingParticipantsTests.cs
@@ -2,6 +2,7 @@ using BookingsApi.Contract.V1.Enums;
 using BookingsApi.Contract.V1.Requests;
 using BookingsApi.Contract.V1.Responses;
 using BookingsApi.Validations.V1;
+using Testing.Common.Builders.Domain;
 
 namespace BookingsApi.IntegrationTests.Api.V1.HearingParticipants;
 
@@ -11,7 +12,6 @@ public class UpdateHearingParticipantsTests : ApiTest
     public async Task should_change_a_judge_on_a_confirmed_hearing()
     {
         // arrange
-        var newJudge = "auto_aw.judge_02@hearings.reform.hmcts.net";
         var hearing = await Hooks.SeedVideoHearing(options
             => { options.Case = new Case("UpdateParticipantJudge", "UpdateParticipantJudge"); }, Domain.Enumerations.BookingStatus.Created);
         var judge = hearing.Participants.First(e => e.HearingRole.IsJudge());
@@ -22,13 +22,13 @@ public class UpdateHearingParticipantsTests : ApiTest
             {
                 new()
                 {
-                    ContactEmail = newJudge,
+                    ContactEmail = GenericJudge.ContactEmail,
                     DisplayName = "Judge",  
-                    Username = newJudge,
+                    Username = GenericJudge.Username,
                     HearingRoleName = "Judge",
                     CaseRoleName = "Judge",
-                    FirstName = "Auto",
-                    LastName = "Aw"
+                    FirstName = GenericJudge.FirstName,
+                    LastName = GenericJudge.LastName,
                 }
             }
         };
@@ -42,7 +42,7 @@ public class UpdateHearingParticipantsTests : ApiTest
         // assert
         result.StatusCode.Should().Be(HttpStatusCode.OK, result.Content.ReadAsStringAsync().Result);
         hearingResponse.Participants.Should().NotContain(p => p.Id == judge.Id);
-        hearingResponse.Participants.Should().Contain(p => p.Username == newJudge);
+        hearingResponse.Participants.Should().Contain(p => p.Username == GenericJudge.Username);
         hearingResponse.Status.Should().Be(BookingStatus.Created);
     }
     

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/HearingParticipants/UpdateHearingParticipantsTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/HearingParticipants/UpdateHearingParticipantsTests.cs
@@ -7,7 +7,45 @@ namespace BookingsApi.IntegrationTests.Api.V1.HearingParticipants;
 
 public class UpdateHearingParticipantsTests : ApiTest
 {
-        
+    [Test]
+    public async Task should_change_a_judge_on_a_confirmed_hearing()
+    {
+        // arrange
+        var newJudge = "auto_aw.judge_02@hearings.reform.hmcts.net";
+        var hearing = await Hooks.SeedVideoHearing(options
+            => { options.Case = new Case("UpdateParticipantJudge", "UpdateParticipantJudge"); }, Domain.Enumerations.BookingStatus.Created);
+        var judge = hearing.Participants.First(e => e.HearingRole.IsJudge());
+        var request = new UpdateHearingParticipantsRequest
+        {
+            RemovedParticipantIds = new List<Guid>{ judge.Id },
+            NewParticipants = new List<ParticipantRequest>
+            {
+                new()
+                {
+                    ContactEmail = newJudge,
+                    DisplayName = "Judge",  
+                    Username = newJudge,
+                    HearingRoleName = "Judge",
+                    CaseRoleName = "Judge",
+                    FirstName = "Auto",
+                    LastName = "Aw"
+                }
+            }
+        };
+
+        // act
+        using var client = Application.CreateClient();
+        var result = await client
+            .PostAsync(ApiUriFactory.HearingParticipantsEndpoints.UpdateHearingParticipants(hearing.Id),RequestBody.Set(request));
+        var updatedHearing = await client.GetAsync(ApiUriFactory.HearingsEndpoints.GetHearingDetailsById(hearing.Id.ToString()));
+        var hearingResponse = await ApiClientResponse.GetResponses<HearingDetailsResponse>(updatedHearing.Content);
+        // assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK, result.Content.ReadAsStringAsync().Result);
+        hearingResponse.Participants.Should().NotContain(p => p.Id == judge.Id);
+        hearingResponse.Participants.Should().Contain(p => p.Username == newJudge);
+        hearingResponse.Status.Should().Be(BookingStatus.Created);
+    }
+    
     [Test]
     public async Task should_remove_a_judge_from_the_confirmed_hearing()
     {

--- a/BookingsApi/BookingsApi.IntegrationTests/ApiTest.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/ApiTest.cs
@@ -10,15 +10,18 @@ public class ApiTest
     protected TestDataManager Hooks { get; private set; }
     private IConfigurationRoot _configRoot;
     private string _databaseConnectionString;
+    protected Person GenericJudge { get; private set; }
 
     [OneTimeSetUp]
     public void OneTimeSetup()
     {
         RegisterSettings();
         RunMigrations();
+        GenericJudge = Hooks.SeedGenericJudgePerson().Result;
         Application = new VhApiWebApplicationFactory();
     }
-    
+
+
     [TearDown]
     public async Task TearDown()
     {

--- a/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Helper/TestDataManager.cs
@@ -329,9 +329,7 @@ namespace BookingsApi.IntegrationTests.Helper
             }
         }
 
-        private async Task AddJudgeToVideoHearing(VideoHearing videoHearing, CaseType caseType,
-            bool useFlatHearingRoles,
-            BookingsDbContext db)
+        private async Task AddJudgeToVideoHearing(VideoHearing videoHearing, CaseType caseType, bool useFlatHearingRoles, BookingsDbContext db)
         {
             if (useFlatHearingRoles)
             {
@@ -723,6 +721,15 @@ namespace BookingsApi.IntegrationTests.Helper
 
             seededForRemoval.ForEach(vh => vh.Deallocate());
             await db.SaveChangesAsync();
+        }
+
+        public async Task<Person> SeedGenericJudgePerson()
+        {
+            await using var db = new BookingsDbContext(_dbContextOptions);
+            var newJudge = new PersonBuilder().Build();
+            var genericJudge = await db.Persons.AddAsync(newJudge);
+            await db.SaveChangesAsync();
+            return genericJudge.Entity;
         }
     }
 }

--- a/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
+++ b/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
@@ -118,10 +118,8 @@ public class HearingParticipantService : IHearingParticipantService
                 eventExistingParticipants, 
                 eventNewParticipants);
 
-        if (eventNewParticipants.Exists(x => x.HearingRole.UserRole.Name == "Judge"))
-        {
+        if (eventNewParticipants.Exists(x => x.HearingRole.UserRole.Name == "Judge") && hearing.Status != BookingStatus.Created)
             await UpdateHearingStatusAsync(hearing.Id, BookingStatus.Created, "System", string.Empty);
-        }
 
         await _participantAddedToHearingAsynchronousProcess.Start(hearing);
     }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10361

### Change description ###
Changed NewParticipants added to the command handler, to be created as a new list of values rather than by reference, so that when the handler removes the judge from the list, it doesnt effect the NewParticipants list which needs to be passed to the integration events to update the conference
