### PR TITLE
VIH-10475 Filter existing participants before publish

### DIFF
--- a/BookingsApi/BookingsApi.Contract/Interfaces/Requests/IUpdateParticipantRequest.cs
+++ b/BookingsApi/BookingsApi.Contract/Interfaces/Requests/IUpdateParticipantRequest.cs
@@ -5,5 +5,8 @@ namespace BookingsApi.Contract.Interfaces.Requests
     public interface IUpdateParticipantRequest : IRepresentativeInfoRequest
     {
         public Guid ParticipantId { get; set; }
+        public string DisplayName { get; set; }
+        public string TelephoneNumber { get; set; }
+        public string Title { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/HearingParticipants/UpdateHearingParticipantsTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/HearingParticipants/UpdateHearingParticipantsTests.cs
@@ -1,13 +1,57 @@
 using BookingsApi.Contract.V1.Enums;
 using BookingsApi.Contract.V1.Requests;
 using BookingsApi.Contract.V1.Responses;
+using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
+using BookingsApi.Infrastructure.Services.ServiceBusQueue;
 using BookingsApi.Validations.V1;
-using Testing.Common.Builders.Domain;
 
 namespace BookingsApi.IntegrationTests.Api.V1.HearingParticipants;
 
 public class UpdateHearingParticipantsTests : ApiTest
 {
+    [Test]
+    public async Task should_update_an_existing_participant()
+    {
+        // arrange
+        var hearing = await Hooks.SeedVideoHearing(options
+            => { options.Case = new Case("UpdateParticipantJudge", "UpdateParticipantJudge"); }, Domain.Enumerations.BookingStatus.Created);
+        var participant = hearing.Participants.First(e => e.HearingRole.Name == "Litigant in person");
+        var request = new UpdateHearingParticipantsRequest
+        {
+            ExistingParticipants = new List<UpdateParticipantRequest> { new()
+            {
+                ParticipantId = participant.Id, 
+                DisplayName = "NewDisplayName",
+                ContactEmail = participant.Person?.ContactEmail,
+                FirstName = participant.Person?.FirstName,
+                LastName = participant.Person?.LastName,
+                OrganisationName = participant.Person?.Organisation?.Name,
+                TelephoneNumber = participant.Person?.TelephoneNumber,
+                Title = participant.Person?.Title
+            } }
+        };
+
+        // act
+        using var client = Application.CreateClient();
+        var result = await client
+            .PostAsync(ApiUriFactory.HearingParticipantsEndpoints.UpdateHearingParticipants(hearing.Id),RequestBody.Set(request));
+        var updatedHearing = await client.GetAsync(ApiUriFactory.HearingsEndpoints.GetHearingDetailsById(hearing.Id.ToString()));
+        var hearingResponse = await ApiClientResponse.GetResponses<HearingDetailsResponse>(updatedHearing.Content);
+        
+        // assert
+        hearingResponse.Participants.Should().Contain(p => p.DisplayName == "NewDisplayName");
+        result.StatusCode.Should().Be(HttpStatusCode.OK, result.Content.ReadAsStringAsync().Result);
+        var serviceBusStub = Application.Services.GetService(typeof(IServiceBusQueueClient)) as ServiceBusQueueClientFake;
+        var messages = serviceBusStub!.ReadAllMessagesFromQueue(hearing.Id);
+        var participantMessages = messages
+            .Where(x => x.IntegrationEvent is ParticipantUpdatedIntegrationEvent)
+            .Select(x => x.IntegrationEvent as ParticipantUpdatedIntegrationEvent)
+            .Where(x => x.HearingId == hearing.Id)
+            .ToList();
+
+        participantMessages.Count.Should().Be(1);
+    }
+    
     [Test]
     public async Task should_change_a_judge_on_a_confirmed_hearing()
     {

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingsInGroupV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingsInGroupV2Tests.cs
@@ -59,7 +59,10 @@ namespace BookingsApi.IntegrationTests.Api.V2.Hearings
                 var participantToRemove = requestHearing.Participants.ExistingParticipants.First(p => p.ParticipantId != defenceAdvocateParticipant.Id);
                 requestHearing.Participants.RemovedParticipantIds.Add(participantToRemove.ParticipantId);
                 requestHearing.Participants.ExistingParticipants.Remove(participantToRemove);
-            
+                           
+                // Update a participant
+                requestHearing.Participants.ExistingParticipants[0].DisplayName = "UpdatedDisplayName";
+
                 // Add an endpoint
                 requestHearing.Endpoints.NewEndpoints.Add(newEndpoint);
                 
@@ -103,7 +106,7 @@ namespace BookingsApi.IntegrationTests.Api.V2.Hearings
                 AssertParticipantsUpdated(updatedHearing, requestHearing);
                 AssertEndpointsUpdated(updatedHearing, requestHearing);
                 AssertJudiciaryParticipantsUpdated(updatedHearing, requestHearing);
-                AssertEventsPublished(updatedHearing, requestHearing);
+                AssertEventsPublished(updatedHearing, requestHearing, existingParticipantsUpdated: 1);
             }
         }
 
@@ -512,7 +515,7 @@ namespace BookingsApi.IntegrationTests.Api.V2.Hearings
             }
         }
 
-        private void AssertEventsPublished(Hearing hearing, HearingRequestV2 requestHearing)
+        private void AssertEventsPublished(Hearing hearing, HearingRequestV2 requestHearing, int existingParticipantsUpdated)
         {
             var serviceBusStub = Application.Services
                 .GetService(typeof(IServiceBusQueueClient)) as ServiceBusQueueClientFake;
@@ -536,12 +539,11 @@ namespace BookingsApi.IntegrationTests.Api.V2.Hearings
                 var participantMessage = participantMessages.Single();
 
                 var expectedAddedCount = requestHearing.Participants.NewParticipants.Count;
-                var expectedUpdatedCount = requestHearing.Participants.ExistingParticipants.Count;
                 var expectedRemovedCount = requestHearing.Participants.RemovedParticipantIds.Count;
                 var expectedLinkedCount = requestHearing.Participants.LinkedParticipants.Count;
 
                 participantMessage.NewParticipants.Count.Should().Be(expectedAddedCount);
-                participantMessage.ExistingParticipants.Count.Should().Be(expectedUpdatedCount);
+                participantMessage.ExistingParticipants.Count.Should().Be(existingParticipantsUpdated);
                 participantMessage.RemovedParticipants.Count.Should().Be(expectedRemovedCount);
                 participantMessage.LinkedParticipants.Count.Should().Be(expectedLinkedCount);
             }

--- a/BookingsApi/BookingsApi/Controllers/V1/HearingParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/V1/HearingParticipantsController.cs
@@ -10,7 +10,7 @@ namespace BookingsApi.Controllers.V1
     [Route("hearings")]
     [ApiVersion("1.0")]
     [ApiController]
-    public class HearingParticipantsController : Controller
+    public class  HearingParticipantsController : Controller
     {
         private readonly IQueryHandler _queryHandler;
         private readonly ICommandHandler _commandHandler;

--- a/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
+++ b/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
@@ -134,12 +134,11 @@ public class HearingParticipantService : IHearingParticipantService
         foreach (var existingParticipantRequest in request.ExistingParticipants)
         {
             var existingParticipant = existingParticipants.SingleOrDefault(ep => ep.Id == existingParticipantRequest.ParticipantId);
-
-            if (existingParticipant == null)
-            {
+            var isNotBeingUpdated = !CheckParticipantIsBeingUpdated(existingParticipant, existingParticipantRequest);
+            
+            if (existingParticipant == null || isNotBeingUpdated)
                 continue;
-            }
-
+            
             var existingParticipantDetail = new ExistingParticipantDetails
             {
                 DisplayName = existingParticipantRequest.DisplayName,
@@ -201,13 +200,11 @@ public class HearingParticipantService : IHearingParticipantService
 
         foreach (var existingParticipantRequest in request.ExistingParticipants)
         {
-            var existingParticipant =
-                existingParticipants.SingleOrDefault(ep => ep.Id == existingParticipantRequest.ParticipantId);
-
-            if (existingParticipant == null)
-            {
+            var existingParticipant = existingParticipants.SingleOrDefault(ep => ep.Id == existingParticipantRequest.ParticipantId);
+            var isNotBeingUpdated = !CheckParticipantIsBeingUpdated(existingParticipant, existingParticipantRequest);
+            
+            if (existingParticipant == null || isNotBeingUpdated)
                 continue;
-            }
 
             var existingParticipantDetail = new ExistingParticipantDetails
             {
@@ -291,4 +288,11 @@ public class HearingParticipantService : IHearingParticipantService
         var command = new UpdateHearingStatusCommand(hearingId, bookingStatus, updatedBy, cancelReason);
         await _commandHandler.Handle(command);
     }
+    
+    //Only properties that can be updated on an existing Participant, otherwise should be excluded from updates to the video-api
+    private static bool CheckParticipantIsBeingUpdated(Participant existingParticipant, IUpdateParticipantRequest requestChanges) => 
+        existingParticipant?.Person?.Title != requestChanges.Title ||
+        existingParticipant?.Person?.Organisation?.Name != requestChanges.OrganisationName ||
+        existingParticipant?.Person?.TelephoneNumber != requestChanges.TelephoneNumber ||
+        existingParticipant?.DisplayName != requestChanges.DisplayName;
 }

--- a/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
+++ b/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
@@ -201,8 +201,9 @@ public class HearingParticipantService : IHearingParticipantService
         foreach (var existingParticipantRequest in request.ExistingParticipants)
         {
             var existingParticipant = existingParticipants.SingleOrDefault(ep => ep.Id == existingParticipantRequest.ParticipantId);
+            var isNotBeingUpdated = !CheckParticipantIsBeingUpdated(existingParticipant, existingParticipantRequest);
             
-            if (existingParticipant == null)
+            if (existingParticipant == null || isNotBeingUpdated)
                 continue;
 
             var existingParticipantDetail = new ExistingParticipantDetails

--- a/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
+++ b/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
@@ -201,9 +201,8 @@ public class HearingParticipantService : IHearingParticipantService
         foreach (var existingParticipantRequest in request.ExistingParticipants)
         {
             var existingParticipant = existingParticipants.SingleOrDefault(ep => ep.Id == existingParticipantRequest.ParticipantId);
-            var isNotBeingUpdated = !CheckParticipantIsBeingUpdated(existingParticipant, existingParticipantRequest);
             
-            if (existingParticipant == null || isNotBeingUpdated)
+            if (existingParticipant == null)
                 continue;
 
             var existingParticipantDetail = new ExistingParticipantDetails
@@ -290,9 +289,12 @@ public class HearingParticipantService : IHearingParticipantService
     }
     
     //Check the only properties that can be updated on an existing Participant have been edited, otherwise should be excluded from updates to the video-api
-    private static bool CheckParticipantIsBeingUpdated(Participant existingParticipant, IUpdateParticipantRequest requestChanges) => 
-        existingParticipant?.Person?.Title != requestChanges.Title ||
-        existingParticipant?.Person?.Organisation?.Name != requestChanges.OrganisationName ||
-        existingParticipant?.Person?.TelephoneNumber != requestChanges.TelephoneNumber ||
-        existingParticipant?.DisplayName != requestChanges.DisplayName;
+    private static bool CheckParticipantIsBeingUpdated(Participant existingParticipant, IUpdateParticipantRequest requestChanges)
+    {
+        return existingParticipant?.Person?.Title != requestChanges.Title ||
+               existingParticipant?.Person?.Organisation?.Name != requestChanges.OrganisationName ||
+               existingParticipant?.Person?.TelephoneNumber != requestChanges.TelephoneNumber ||
+               existingParticipant?.DisplayName != requestChanges.DisplayName;
+    }
+        
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10475

### Change description ###
Have added function to UpdateParticipants methods, that determines whether an existing participant is actually being updated. If not will exclude from list sent to BQS/video-api. This is because it will overwrite any video participant data, that may have been changed via video-web i.e. DisplayName


