### PR TITLE
VIH-10493 Fix - multiday notifications not sent when new notify templates are toggled off

### DIFF
--- a/BookingsApi/BookingsApi.Infrastructure.Services/AsynchronousProcesses/MultidayHearingAsynchronousProcess.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/AsynchronousProcesses/MultidayHearingAsynchronousProcess.cs
@@ -33,7 +33,9 @@ namespace BookingsApi.Infrastructure.Services.AsynchronousProcesses
             }
             if (!_featureToggles.UsePostMay2023Template())
             {
-                await _publisherFactory.Get(EventType.MultiDayHearingIntegrationEvent).PublishAsync(videoHearing);
+                var publisherForMultiDayEvent = (IPublishMultidayEvent)_publisherFactory.Get(EventType.MultiDayHearingIntegrationEvent);
+                publisherForMultiDayEvent.TotalDays = totalDays;
+                await publisherForMultiDayEvent.PublishAsync(videoHearing);
 
                 return;
             }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/HearingConfirmationForParticipantDto.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/HearingConfirmationForParticipantDto.cs
@@ -8,7 +8,7 @@ namespace BookingsApi.Infrastructure.Services.Dtos
         public DateTime ScheduledDateTime { get; set; }
         public string CaseName { get; set; }
         public string CaseNumber { get; set; }
-        public Guid ParticipnatId { get; set; }
+        public Guid ParticipantId { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string DisplayName { get; set; }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/EventDtoMappers.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/EventDtoMappers.cs
@@ -38,7 +38,7 @@ namespace BookingsApi.Infrastructure.Services
                 ContactTelephone = participant.GetContactTelephone(),
                 FirstName = participant.FirstName,
                 LastName = participant.LastName,
-                ParticipnatId = participant.ParticipantId,
+                ParticipantId = participant.ParticipantId,
                 UserRole = participant.UserRole
             };
         }
@@ -58,7 +58,7 @@ namespace BookingsApi.Infrastructure.Services
                 ContactTelephone = participant.JudiciaryPerson.WorkPhone,
                 FirstName = participant.JudiciaryPerson.KnownAs,
                 LastName = participant.JudiciaryPerson.Surname,
-                ParticipnatId = participant.Id,
+                ParticipantId = participant.Id,
                 UserRole =  GetUserRole(participant.HearingRoleCode)
             };
         }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/HearingConfirmationForParticipantDtoMapper.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/HearingConfirmationForParticipantDtoMapper.cs
@@ -5,7 +5,7 @@ using BookingsApi.Infrastructure.Services.Dtos;
 
 namespace BookingsApi.Infrastructure.Services
 {
-    public class HearingConfirmationForParticipantDtoMapper
+    public abstract class HearingConfirmationForParticipantDtoMapper
     {
         public static IEnumerable<HearingConfirmationForParticipantDto> MapToDtos(Hearing hearing)
         {

--- a/BookingsApi/BookingsApi.Infrastructure.Services/HearingConfirmationForParticipantDtoMapper.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/HearingConfirmationForParticipantDtoMapper.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+using BookingsApi.Domain;
+using BookingsApi.Infrastructure.Services.Dtos;
+
+namespace BookingsApi.Infrastructure.Services
+{
+    public class HearingConfirmationForParticipantDtoMapper
+    {
+        public static IEnumerable<HearingConfirmationForParticipantDto> MapToDtos(Hearing hearing)
+        {
+            var participantDtos = hearing.Participants
+                .Select(p => ParticipantDtoMapper.MapToDto(p, hearing.OtherInformation))
+                .ToList();
+            var judiciaryParticipantDtos = hearing.JudiciaryParticipants
+                .Select(ParticipantDtoMapper.MapToDto)
+                .ToList();
+            var allParticipantDtos = participantDtos.Union(judiciaryParticipantDtos).ToList();
+            var @case = hearing.GetCases()[0];
+            var hearingConfirmationDtos = allParticipantDtos
+                .Select(p => EventDtoMappers.MapToHearingConfirmationDto(
+                    hearing.Id, hearing.ScheduledDateTime, p, @case))
+                .ToList();
+
+            return hearingConfirmationDtos;
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/MultiDayHearingIntegrationEvent.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/MultiDayHearingIntegrationEvent.cs
@@ -1,14 +1,15 @@
-﻿using System;
-using BookingsApi.Infrastructure.Services.Dtos;
+﻿using BookingsApi.Infrastructure.Services.Dtos;
 
 namespace BookingsApi.Infrastructure.Services.IntegrationEvents.Events
 {
     public class MultiDayHearingIntegrationEvent : IIntegrationEvent
     {
-        public MultiDayHearingIntegrationEvent(HearingConfirmationForParticipantDto dto)
+        public MultiDayHearingIntegrationEvent(HearingConfirmationForParticipantDto dto, int totalDays)
         {
             HearingConfirmationForParticipant = dto;
+            TotalDays = totalDays;
         }
         public HearingConfirmationForParticipantDto HearingConfirmationForParticipant { get; }
+        public int TotalDays { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Publishers/MultidayHearingNotificationEventPublisher.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Publishers/MultidayHearingNotificationEventPublisher.cs
@@ -26,6 +26,14 @@ namespace BookingsApi.Infrastructure.Services.Publishers
                 await _eventPublisher.PublishAsync(new MultiDayHearingIntegrationEvent(EventDtoMappers.MapToHearingConfirmationDto(
                     videoHearing.Id, videoHearing.ScheduledDateTime, participantDto, @case), TotalDays));
             }
+
+            foreach (var judiciaryParticipant in videoHearing.JudiciaryParticipants)
+            {
+                var participantDto = ParticipantDtoMapper.MapToDto(judiciaryParticipant);
+                
+                await _eventPublisher.PublishAsync(new MultiDayHearingIntegrationEvent(EventDtoMappers.MapToHearingConfirmationDto(
+                    videoHearing.Id, videoHearing.ScheduledDateTime, participantDto, @case), TotalDays));
+            }
         }
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Publishers/MultidayHearingNotificationEventPublisher.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Publishers/MultidayHearingNotificationEventPublisher.cs
@@ -5,15 +5,16 @@ using System.Threading.Tasks;
 
 namespace BookingsApi.Infrastructure.Services.Publishers
 {
-    public class MultidayHearingNotoficationEventPublisher : IPublishEvent
+    public class MultidayHearingNotificationEventPublisher : IPublishMultidayEvent
     {
         private readonly IEventPublisher _eventPublisher;
-        public MultidayHearingNotoficationEventPublisher(IEventPublisher eventPublisher)
+        public MultidayHearingNotificationEventPublisher(IEventPublisher eventPublisher)
         {
             _eventPublisher = eventPublisher;
         }
 
         public EventType EventType => EventType.MultiDayHearingIntegrationEvent;
+        public int TotalDays { get; set; }
 
         public async Task PublishAsync(VideoHearing videoHearing)
         {
@@ -23,7 +24,7 @@ namespace BookingsApi.Infrastructure.Services.Publishers
                 var participantDto = ParticipantDtoMapper.MapToDto(participant, videoHearing.OtherInformation);
                 
                 await _eventPublisher.PublishAsync(new MultiDayHearingIntegrationEvent(EventDtoMappers.MapToHearingConfirmationDto(
-                    videoHearing.Id, videoHearing.ScheduledDateTime, participantDto, @case)));
+                    videoHearing.Id, videoHearing.ScheduledDateTime, participantDto, @case), TotalDays));
             }
         }
     }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
@@ -193,7 +193,7 @@ public class CloneHearingTests : ApiTest
         var messages = serviceBusStub!
             .ReadAllMessagesFromQueue(hearing.Id);
             
-        const int expectedTotalMessageCount = 5;
+        var expectedTotalMessageCount = hearing.Participants.Count;
         var totalDays = request.Dates.Count + 1;
         
         messages.Count(x => x.IntegrationEvent is MultiDayHearingIntegrationEvent).Should().Be(expectedTotalMessageCount);

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
@@ -1,7 +1,13 @@
+using BookingsApi.Common.Services;
 using BookingsApi.Contract.V1.Requests;
 using BookingsApi.Contract.V1.Responses;
+using BookingsApi.Infrastructure.Services;
+using BookingsApi.Infrastructure.Services.Dtos;
+using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
+using BookingsApi.Infrastructure.Services.ServiceBusQueue;
 using BookingsApi.Mappings.Common;
 using BookingsApi.Validations.V1;
+using Testing.Common.Stubs;
 using Constants = BookingsApi.Contract.V1.Constants;
 
 namespace BookingsApi.IntegrationTests.Api.V1.Hearings;
@@ -110,6 +116,31 @@ public class CloneHearingTests : ApiTest
     }
 
     [Test]
+    public async Task should_clone_hearing_for_v1_and_new_notify_templates_feature_toggled_off()
+    {
+        // arrange
+        var startingDate = DateTime.UtcNow.AddMinutes(5);
+        var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true, configureOptions: options =>
+        {
+            options.ScheduledDate = startingDate;
+        });
+
+        var dates = new List<DateTime> {startingDate.AddDays(2), startingDate.AddDays(3)};
+        
+        var featureToggles = (FeatureTogglesStub)Application.Services.GetService(typeof(IFeatureToggles));
+        featureToggles.NewTemplates = false;
+
+        // act
+        using var client = Application.CreateClient();
+        var request = new CloneHearingRequest { Dates = dates }; // No duration specified - should use the default
+        var result = await client.PostAsync(ApiUriFactory.HearingsEndpoints.CloneHearing(hearing1.Id), RequestBody.Set(request));
+        
+        // assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK, result.Content.ReadAsStringAsync().Result);
+        AssertEventsPublishedForV1AndNotifyFeatureOff(request, hearing1);
+    }
+
+    [Test]
     public async Task should_return_validation_error_when_validation_fails()
     {
         // arrange
@@ -153,5 +184,40 @@ public class CloneHearingTests : ApiTest
             judiciaryParticipant.Should().NotBeNull();
             clonedJudiciaryParticipant.Should().BeEquivalentTo(mapper.MapJudiciaryParticipantToResponse(judiciaryParticipant));
         }
+    }
+
+    private void AssertEventsPublishedForV1AndNotifyFeatureOff(CloneHearingRequest request, Hearing hearing)
+    {
+        var serviceBusStub = Application.Services
+            .GetService(typeof(IServiceBusQueueClient)) as ServiceBusQueueClientFake;
+        var messages = serviceBusStub!
+            .ReadAllMessagesFromQueue(hearing.Id);
+            
+        const int expectedTotalMessageCount = 5;
+        var totalDays = request.Dates.Count + 1;
+        
+        messages.Count(x => x.IntegrationEvent is MultiDayHearingIntegrationEvent).Should().Be(expectedTotalMessageCount);
+        var hearingConfirmationDtos = GetHearingConfirmationDtos(hearing);
+        var multiDayIntegrationEvents = messages
+            .Where(x => x.IntegrationEvent is MultiDayHearingIntegrationEvent)
+            .Select(x => x.IntegrationEvent as MultiDayHearingIntegrationEvent)
+            .ToList();
+        multiDayIntegrationEvents.TrueForAll(x => x.TotalDays == totalDays).Should().BeTrue();
+        multiDayIntegrationEvents.Select(x => x.HearingConfirmationForParticipant)
+            .Should().BeEquivalentTo(hearingConfirmationDtos);
+    }
+    
+    private static IEnumerable<HearingConfirmationForParticipantDto> GetHearingConfirmationDtos(Hearing hearing)
+    {
+        var participantDtos = hearing.Participants
+            .Select(p => ParticipantDtoMapper.MapToDto(p, hearing.OtherInformation))
+            .ToList();
+        var @case = hearing.GetCases()[0];
+        var hearingConfirmationDtos = participantDtos
+            .Select(p => EventDtoMappers.MapToHearingConfirmationDto(
+                hearing.Id, hearing.ScheduledDateTime, p, @case))
+            .ToList();
+
+        return hearingConfirmationDtos;
     }
 }

--- a/BookingsApi/BookingsApi.UnitTests/EventPublisherFactoryInstance.cs
+++ b/BookingsApi/BookingsApi.UnitTests/EventPublisherFactoryInstance.cs
@@ -19,7 +19,7 @@ namespace BookingsApi.UnitTests
                 new MultidayHearingConfirmationforExistingParticipantsPublisher(eventPublisher),
                 new CreateAndNotifyUserPublisher(eventPublisher),
                 new HearingNotoficationEventPublisher(eventPublisher),
-                new MultidayHearingNotoficationEventPublisher(eventPublisher),
+                new MultidayHearingNotificationEventPublisher(eventPublisher),
                 new HearingNotificationEventForJudiciaryParticipantPublisher(eventPublisher),
                 new JudiciaryParticipantAddedPublisher(eventPublisher)
             });

--- a/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/EventDtoMappersTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/EventDtoMappersTests.cs
@@ -44,7 +44,7 @@ public class EventDtoMappersTests
         mappedParticipant.ContactTelephone.Should().Be(judiciaryParticipant.JudiciaryPerson.WorkPhone);
         mappedParticipant.FirstName.Should().Be(judiciaryParticipant.JudiciaryPerson.KnownAs);
         mappedParticipant.LastName.Should().Be(judiciaryParticipant.JudiciaryPerson.Surname);
-        mappedParticipant.ParticipnatId.Should().Be(judiciaryParticipant.Id);
+        mappedParticipant.ParticipantId.Should().Be(judiciaryParticipant.Id);
         mappedParticipant.UserRole.Should().Be(role);
     }
     
@@ -102,7 +102,7 @@ public class EventDtoMappersTests
         mappedParticipant.ContactTelephone.Should().Be(participant.Person.TelephoneNumber);
         mappedParticipant.FirstName.Should().Be(participant.Person.FirstName);
         mappedParticipant.LastName.Should().Be(participant.Person.LastName);
-        mappedParticipant.ParticipnatId.Should().Be(participant.Id);
+        mappedParticipant.ParticipantId.Should().Be(participant.Id);
         mappedParticipant.UserRole.Should().Be(participant.HearingRole.UserRole.Name);
     }
 
@@ -148,7 +148,7 @@ public class EventDtoMappersTests
         mappedParticipant.ContactTelephone.Should().Be("0123456");
         mappedParticipant.FirstName.Should().Be(participant.Person.FirstName);
         mappedParticipant.LastName.Should().Be(participant.Person.LastName);
-        mappedParticipant.ParticipnatId.Should().Be(participant.Id);
+        mappedParticipant.ParticipantId.Should().Be(participant.Id);
         mappedParticipant.UserRole.Should().Be(participant.HearingRole.UserRole.Name);
     }
 

--- a/BookingsApi/BookingsApi.UnitTests/Services/ClonedMultidaysAsynchronousProcessTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Services/ClonedMultidaysAsynchronousProcessTests.cs
@@ -31,7 +31,7 @@ namespace BookingsApi.UnitTests.Services
         }
         
         [Test]
-        public async Task Should_publish_messages_with_new_notify_templates_feature_toggled_on()
+        public async Task Should_publish_messages_with_new_notify_templates_feature_on()
         {
             var hearing = new VideoHearingBuilder().WithCase().Build();
             hearing.Participants[0].Person.GetType().GetProperty("CreatedDate").SetValue(hearing.Participants[0].Person, 
@@ -63,50 +63,62 @@ namespace BookingsApi.UnitTests.Services
         }
 
         [Test]
-        public async Task Should_publish_messages_with_new_notify_templates_feature_toggled_off()
+        public async Task Should_publish_messages_for_v1_with_new_notify_templates_feature_off()
         {
             // Arrange
             var hearing = new VideoHearingBuilder().WithCase().Build();
-            hearing.Participants[0].Person.GetType().GetProperty("CreatedDate").SetValue(hearing.Participants[0].Person, 
-                hearing.Participants[0].Person.CreatedDate.AddDays(-10), null);
-            hearing.Participants[1].Person.GetType().GetProperty("CreatedDate").SetValue(hearing.Participants[1].Person,
-                hearing.Participants[1].Person.CreatedDate.AddDays(-10), null);
 
             ((FeatureTogglesStub)_featureToggles).NewTemplates = false;
 
-            var expectedTotalMessageCount = 6;
-            var totalDays = 2;
+            const int expectedTotalMessageCount = 6;
+            const int totalDays = 2;
             
             // Act
             await _clonedMultidaysAsynchronousProcess.Start(hearing, totalDays);
             
             // Assert
-            var messages = _serviceBusQueueClient.ReadAllMessagesFromQueue(hearing.Id);
-            messages.Length.Should().Be(expectedTotalMessageCount);
+            AssertEventsPublishedForNotifyFeatureOff(hearing, totalDays, expectedTotalMessageCount);
+        }
+        
+        [Test]
+        public async Task Should_publish_messages_with_v2_with_new_notify_templates_feature_off()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder(addJudge: false).WithCase().Build();
+            var judiciaryJudgePerson = new JudiciaryPersonBuilder(Guid.NewGuid().ToString()).Build();
+            hearing.AddJudiciaryJudge(judiciaryJudgePerson, "Judiciary Judge");
+            var panelMemberParticipants = hearing.Participants.Where(p => p is JudicialOfficeHolder).ToList();
+            foreach (var participant in panelMemberParticipants)
+            {
+                // Remove these since they are V1 johs and not applicable to V2
+                hearing.Participants.Remove(participant);
+            }
+
+            ((FeatureTogglesStub)_featureToggles).NewTemplates = false;
+
+            const int expectedTotalMessageCount = 5;
+            const int totalDays = 2;
             
+            // Act
+            await _clonedMultidaysAsynchronousProcess.Start(hearing, totalDays);
+            
+            // Assert
+            AssertEventsPublishedForNotifyFeatureOff(hearing, totalDays, expectedTotalMessageCount);
+        }
+        
+        private void AssertEventsPublishedForNotifyFeatureOff(Hearing hearing, int totalDayCount, int expectedTotalMessageCount)
+        {
+            var messages = _serviceBusQueueClient.ReadAllMessagesFromQueue(hearing.Id);
+
             messages.Count(x => x.IntegrationEvent is MultiDayHearingIntegrationEvent).Should().Be(expectedTotalMessageCount);
-            var hearingConfirmationDtos = GetHearingConfirmationDtos(hearing);
+            var hearingConfirmationDtos = HearingConfirmationForParticipantDtoMapper.MapToDtos(hearing);
             var multiDayIntegrationEvents = messages
                 .Where(x => x.IntegrationEvent is MultiDayHearingIntegrationEvent)
                 .Select(x => x.IntegrationEvent as MultiDayHearingIntegrationEvent)
                 .ToList();
-            multiDayIntegrationEvents.TrueForAll(x => x.TotalDays == totalDays).Should().BeTrue();
+            multiDayIntegrationEvents.TrueForAll(x => x.TotalDays == totalDayCount).Should().BeTrue();
             multiDayIntegrationEvents.Select(x => x.HearingConfirmationForParticipant)
                 .Should().BeEquivalentTo(hearingConfirmationDtos);
-        }
-
-        private static IEnumerable<HearingConfirmationForParticipantDto> GetHearingConfirmationDtos(Hearing hearing)
-        {
-            var participantDtos = hearing.Participants
-                .Select(p => ParticipantDtoMapper.MapToDto(p, hearing.OtherInformation))
-                .ToList();
-            var @case = hearing.GetCases()[0];
-            var hearingConfirmationDtos = participantDtos
-                .Select(p => EventDtoMappers.MapToHearingConfirmationDto(
-                    hearing.Id, hearing.ScheduledDateTime, p, @case))
-                .ToList();
-
-            return hearingConfirmationDtos;
         }
     }
 }

--- a/BookingsApi/BookingsApi.UnitTests/Services/ClonedMultidaysAsynchronousProcessTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Services/ClonedMultidaysAsynchronousProcessTests.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
 using BookingsApi.Common.Services;
+using BookingsApi.Domain;
 using BookingsApi.Domain.Participants;
+using BookingsApi.Infrastructure.Services;
 using BookingsApi.Infrastructure.Services.AsynchronousProcesses;
+using BookingsApi.Infrastructure.Services.Dtos;
 using BookingsApi.Infrastructure.Services.IntegrationEvents;
 using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
 using BookingsApi.Infrastructure.Services.Publishers;
@@ -27,7 +31,7 @@ namespace BookingsApi.UnitTests.Services
         }
         
         [Test]
-        public async Task Should_publish_messages_for_single_day_booking()
+        public async Task Should_publish_messages_with_new_notify_templates_feature_toggled_on()
         {
             var hearing = new VideoHearingBuilder().WithCase().Build();
             hearing.Participants[0].Person.GetType().GetProperty("CreatedDate").SetValue(hearing.Participants[0].Person, 
@@ -35,6 +39,8 @@ namespace BookingsApi.UnitTests.Services
             hearing.Participants[1].Person.GetType().GetProperty("CreatedDate").SetValue(hearing.Participants[1].Person,
                 hearing.Participants[1].Person.CreatedDate.AddDays(-10), null);
 
+            ((FeatureTogglesStub)_featureToggles).NewTemplates = true;
+            
             var judgeAsExistingParticipant = 1;
             var createConfereceMessageCount = 0;
             var newParticipantWelcomeMessageCount = 0;
@@ -54,6 +60,53 @@ namespace BookingsApi.UnitTests.Services
             messages.Count(x => x.IntegrationEvent is HearingIsReadyForVideoIntegrationEvent).Should().Be(createConfereceMessageCount);
             messages.Count(x => x.IntegrationEvent is ExistingParticipantMultidayHearingConfirmationEvent).
                 Should().Be(mulitdayHearingConfirmationForExistingParticipantsMessageCount + judgeAsExistingParticipant);
+        }
+
+        [Test]
+        public async Task Should_publish_messages_with_new_notify_templates_feature_toggled_off()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().WithCase().Build();
+            hearing.Participants[0].Person.GetType().GetProperty("CreatedDate").SetValue(hearing.Participants[0].Person, 
+                hearing.Participants[0].Person.CreatedDate.AddDays(-10), null);
+            hearing.Participants[1].Person.GetType().GetProperty("CreatedDate").SetValue(hearing.Participants[1].Person,
+                hearing.Participants[1].Person.CreatedDate.AddDays(-10), null);
+
+            ((FeatureTogglesStub)_featureToggles).NewTemplates = false;
+
+            var expectedTotalMessageCount = 6;
+            var totalDays = 2;
+            
+            // Act
+            await _clonedMultidaysAsynchronousProcess.Start(hearing, totalDays);
+            
+            // Assert
+            var messages = _serviceBusQueueClient.ReadAllMessagesFromQueue(hearing.Id);
+            messages.Length.Should().Be(expectedTotalMessageCount);
+            
+            messages.Count(x => x.IntegrationEvent is MultiDayHearingIntegrationEvent).Should().Be(expectedTotalMessageCount);
+            var hearingConfirmationDtos = GetHearingConfirmationDtos(hearing);
+            var multiDayIntegrationEvents = messages
+                .Where(x => x.IntegrationEvent is MultiDayHearingIntegrationEvent)
+                .Select(x => x.IntegrationEvent as MultiDayHearingIntegrationEvent)
+                .ToList();
+            multiDayIntegrationEvents.TrueForAll(x => x.TotalDays == totalDays).Should().BeTrue();
+            multiDayIntegrationEvents.Select(x => x.HearingConfirmationForParticipant)
+                .Should().BeEquivalentTo(hearingConfirmationDtos);
+        }
+
+        private static IEnumerable<HearingConfirmationForParticipantDto> GetHearingConfirmationDtos(Hearing hearing)
+        {
+            var participantDtos = hearing.Participants
+                .Select(p => ParticipantDtoMapper.MapToDto(p, hearing.OtherInformation))
+                .ToList();
+            var @case = hearing.GetCases()[0];
+            var hearingConfirmationDtos = participantDtos
+                .Select(p => EventDtoMappers.MapToHearingConfirmationDto(
+                    hearing.Id, hearing.ScheduledDateTime, p, @case))
+                .ToList();
+
+            return hearingConfirmationDtos;
         }
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10493


### Change description ###

- Pass `TotalDays` property to the published event
- Publish events for judiciary participants
- Fix typo in publisher name
- Fix typo in dto property name (this was actually causing the ParticipantId to deserialise into an empty guid in BQS)