### PR TITLE
VIH-10521 Fix error creating multi-day booking scheduled 30 minutes from now

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
+++ b/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
@@ -27,10 +27,10 @@ namespace BookingsApi.DAL.Services
         /// <summary>
         /// Update the case name of a multi-day hearing, used purely as part of the clone process
         /// </summary>
-        /// <param name="hearingId"></param>
-        /// <param name="caseName"></param>
+        /// <param name="hearingId">Id of the hearing</param>
+        /// <param name="newCaseName">New case name</param>
         /// <returns></returns>
-        Task RenameHearingForMultiDayBooking(Guid hearingId, string caseName);
+        Task RenameHearingForMultiDayBooking(Guid hearingId, string newCaseName);
 
         /// <summary>
         /// Create links between participants if any exist
@@ -155,11 +155,11 @@ namespace BookingsApi.DAL.Services
             await _context.SaveChangesAsync();
         }
 
-        public async Task RenameHearingForMultiDayBooking(Guid hearingId, string caseName)
+        public async Task RenameHearingForMultiDayBooking(Guid hearingId, string newCaseName)
         {
             var hearing = await _context.VideoHearings.Include(x => x.HearingCases).ThenInclude(h => h.Case)
                 .FirstAsync(x => x.Id == hearingId);
-            hearing.RenameHearingForMultiDayBooking(caseName);
+            hearing.RenameHearingForMultiDayBooking(newCaseName);
             await _context.SaveChangesAsync();
         }
 

--- a/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
+++ b/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
@@ -25,6 +25,14 @@ namespace BookingsApi.DAL.Services
         Task UpdateHearingCaseName(Guid hearingId, string caseName);
 
         /// <summary>
+        /// Update the case name of a multi-day hearing, used purely as part of the clone process
+        /// </summary>
+        /// <param name="hearingId"></param>
+        /// <param name="caseName"></param>
+        /// <returns></returns>
+        Task RenameHearingForMultiDayBooking(Guid hearingId, string caseName);
+
+        /// <summary>
         /// Create links between participants if any exist
         /// </summary>
         /// <param name="participants">List of participants in the hearing</param>
@@ -144,6 +152,14 @@ namespace BookingsApi.DAL.Services
             {
                 IsLeadCase = existingCase.IsLeadCase
             });
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task RenameHearingForMultiDayBooking(Guid hearingId, string caseName)
+        {
+            var hearing = await _context.VideoHearings.Include(x => x.HearingCases).ThenInclude(h => h.Case)
+                .FirstAsync(x => x.Id == hearingId);
+            hearing.RenameHearingForMultiDayBooking(caseName);
             await _context.SaveChangesAsync();
         }
 

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -436,6 +436,23 @@ namespace BookingsApi.Domain
             existingCase.Name = @case.Name;
         }
 
+        /// <summary>
+        /// Used exclusively for the clone process, other updates to case name should be done via UpdateCase
+        /// </summary>
+        /// <param name="newName"></param>
+        /// <exception cref="DomainRuleException"></exception>
+        public void RenameHearingForMultiDayBooking(string newName)
+        {
+            if (SourceId == null)
+            {
+                throw new DomainRuleException("CaseName", DomainRuleErrorMessages.HearingNotMultiDay);
+            }
+
+            var existingCase = GetCases().FirstOrDefault();
+            if (existingCase == null) return;
+            existingCase.Name = newName;
+        }
+
         public void UpdateHearingDetails(HearingVenue hearingVenue, DateTime scheduledDateTime,
             int scheduledDuration, string hearingRoomName, string otherInformation, string updatedBy,
             List<Case> cases, bool audioRecordingRequired)

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -435,13 +435,8 @@ namespace BookingsApi.Domain
             existingCase.Number = @case.Number;
             existingCase.Name = @case.Name;
         }
-
-        /// <summary>
-        /// Used exclusively for the clone process, other updates to case name should be done via UpdateCase
-        /// </summary>
-        /// <param name="newName"></param>
-        /// <exception cref="DomainRuleException"></exception>
-        public void RenameHearingForMultiDayBooking(string newName)
+        
+        public void RenameHearingForMultiDayBooking(string newCaseName)
         {
             if (SourceId == null)
             {
@@ -450,7 +445,7 @@ namespace BookingsApi.Domain
 
             var existingCase = GetCases().FirstOrDefault();
             if (existingCase == null) return;
-            existingCase.Name = newName;
+            existingCase.Name = newCaseName;
         }
 
         public void UpdateHearingDetails(HearingVenue hearingVenue, DateTime scheduledDateTime,

--- a/BookingsApi/BookingsApi.Domain/Validations/DomainRuleErrorMessages.cs
+++ b/BookingsApi/BookingsApi.Domain/Validations/DomainRuleErrorMessages.cs
@@ -25,4 +25,5 @@ public static class DomainRuleErrorMessages
     public const string LastNameRequired = "LastName cannot be empty";
     public const string CannotAddJudgeWhenJudiciaryJudgeAlreadyExists = "Cannot add judge when judiciary judge already exists";
     public const string CannotAddJudiciaryJudgeWhenJudgeAlreadyExists = "Cannot add judiciary judge when non-judiciary judge already exists";
+    public const string HearingNotMultiDay = "Hearing is not multi-day";
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
@@ -89,7 +89,7 @@ public class CloneHearingTests : ApiTest
     {
         // arrange
         var startingDate = DateTime.UtcNow.AddMinutes(20);
-        var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true, configureOptions: options =>
+        var hearing1 = await Hooks.SeedVideoHearingV2(isMultiDayFirstHearing:true, configureOptions: options =>
         {
             options.ScheduledDate = startingDate;
         }, status: BookingStatus.Created);

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Hearings/CloneHearingTests.cs
@@ -1,6 +1,7 @@
 using BookingsApi.Common.Services;
 using BookingsApi.Contract.V1.Requests;
 using BookingsApi.Contract.V1.Responses;
+using BookingsApi.Domain.Enumerations;
 using BookingsApi.Infrastructure.Services;
 using BookingsApi.Infrastructure.Services.Dtos;
 using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
@@ -18,11 +19,11 @@ public class CloneHearingTests : ApiTest
     public async Task should_return_all_cloned_hearings_for_the_dates_with_unspecified_duration()
     {
         // arrange
-        var startingDate = DateTime.UtcNow.AddMinutes(5);
+        var startingDate = DateTime.UtcNow.AddHours(1);
         var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true, configureOptions: options =>
         {
             options.ScheduledDate = startingDate;
-        });
+        }, status: BookingStatus.Created);
         var groupId = hearing1.SourceId;
 
         var dates = new List<DateTime> {startingDate.AddDays(2), startingDate.AddDays(3)};
@@ -50,11 +51,11 @@ public class CloneHearingTests : ApiTest
     public async Task should_return_all_cloned_hearings_for_the_dates_with_specified_duration()
     {
         // arrange
-        var startingDate = DateTime.UtcNow.AddMinutes(5);
+        var startingDate = DateTime.UtcNow.AddHours(1);
         var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true, configureOptions: options =>
         {
             options.ScheduledDate = startingDate;
-        });
+        }, status: BookingStatus.Created);
         var groupId = hearing1.SourceId;
 
         var dates = new List<DateTime> {startingDate.AddDays(2), startingDate.AddDays(3)};
@@ -84,16 +85,39 @@ public class CloneHearingTests : ApiTest
     }
 
     [Test]
+    public async Task should_clone_hearing_scheduled_within_30_minutes_from_now()
+    {
+        // arrange
+        var startingDate = DateTime.UtcNow.AddMinutes(20);
+        var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true, configureOptions: options =>
+        {
+            options.ScheduledDate = startingDate;
+        }, status: BookingStatus.Created);
+
+        var dates = new List<DateTime> {startingDate.AddDays(1)};
+        
+        // act
+        using var client = Application.CreateClient();
+        var request = new CloneHearingRequest { Dates = dates, ScheduledDuration = 480};
+        var result = await client.PostAsync(ApiUriFactory.HearingsEndpoints.CloneHearing(hearing1.Id), RequestBody.Set(request));
+        
+        // assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK, result.Content.ReadAsStringAsync().Result);
+        var clonedHearingsList = await ApiClientResponse.GetResponses<List<HearingDetailsResponse>>(result.Content);
+        clonedHearingsList.Count.Should().Be(dates.Count);
+    }
+
+    [Test]
     public async Task should_return_all_cloned_hearings_with_judiciary_participants_for_the_dates()
     {
         // arrange
-        var startingDate = DateTime.UtcNow.AddMinutes(5);
+        var startingDate = DateTime.UtcNow.AddHours(1);
         var hearing1 = await Hooks.SeedVideoHearingV2(isMultiDayFirstHearing:true, configureOptions: options =>
         {
             options.ScheduledDate = startingDate;
             options.AddJudge = true;
             options.AddPanelMember = true;
-        });
+        }, status: BookingStatus.Created);
         var groupId = hearing1.SourceId;
 
         var dates = new List<DateTime> {startingDate.AddDays(2), startingDate.AddDays(3)};
@@ -119,11 +143,11 @@ public class CloneHearingTests : ApiTest
     public async Task should_clone_hearing_for_v1_with_new_notify_templates_feature_off()
     {
         // arrange
-        var startingDate = DateTime.UtcNow.AddMinutes(5);
+        var startingDate = DateTime.UtcNow.AddHours(1);
         var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true, configureOptions: options =>
         {
             options.ScheduledDate = startingDate;
-        });
+        }, status: BookingStatus.Created);
 
         var dates = new List<DateTime> {startingDate.AddDays(2), startingDate.AddDays(3)};
         
@@ -144,11 +168,11 @@ public class CloneHearingTests : ApiTest
     public async Task should_clone_hearing_for_v2_with_new_notify_templates_feature_off()
     {
         // arrange
-        var startingDate = DateTime.UtcNow.AddMinutes(5);
+        var startingDate = DateTime.UtcNow.AddHours(1);
         var hearing1 = await Hooks.SeedVideoHearingV2(isMultiDayFirstHearing:true, configureOptions: options =>
         {
             options.ScheduledDate = startingDate;
-        });
+        }, status: BookingStatus.Created);
 
         var dates = new List<DateTime> {startingDate.AddDays(2), startingDate.AddDays(3)};
         
@@ -169,11 +193,11 @@ public class CloneHearingTests : ApiTest
     public async Task should_return_validation_error_when_validation_fails()
     {
         // arrange
-        var startingDate = DateTime.UtcNow.AddMinutes(5);
+        var startingDate = DateTime.UtcNow.AddHours(1);
         var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true, configureOptions: options =>
         {
             options.ScheduledDate = startingDate;
-        });
+        }, status: BookingStatus.Created);
 
         var dates = new List<DateTime> {startingDate.AddDays(2), startingDate.AddDays(3)};
         const int specifiedDuration = -1; // Invalid value

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/CloneHearingTests.cs
@@ -64,7 +64,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
             objectResult.Value.Should().BeOfType<List<HearingDetailsResponse>>();
             CommandHandlerMock.Verify(c => c.Handle(It.Is<CreateVideoHearingCommand>(c => c.ScheduledDateTime == request.Dates[0] && c.Cases[0].Name == "Case name Day 2 of 3")), Times.Once);
             CommandHandlerMock.Verify(c => c.Handle(It.Is<CreateVideoHearingCommand>(c => c.ScheduledDateTime == request.Dates[1] && c.Cases[0].Name == "Case name Day 3 of 3")), Times.Once);
-            HearingServiceMock.Verify(h => h.UpdateHearingCaseName(It.Is<Guid>(g => g == hearingId), It.Is<string>(x => x == caseName)), Times.Once);
+            HearingServiceMock.Verify(h => h.RenameHearingForMultiDayBooking(It.Is<Guid>(g => g == hearingId), It.Is<string>(x => x == caseName)), Times.Once);
 
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<NewParticipantMultidayHearingConfirmationEvent>()), Times.Exactly(hearing.Participants.Count(x => x is not JudicialOfficeHolder)));
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<ExistingParticipantMultidayHearingConfirmationEvent>()), Times.Exactly(judgeAsExistingParticipantCount));
@@ -91,7 +91,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
             objectResult.Value.Should().BeOfType<List<HearingDetailsResponse>>();
             CommandHandlerMock.Verify(c => c.Handle(It.Is<CreateVideoHearingCommand>(c => c.ScheduledDateTime == request.Dates[0] && c.Cases[0].Name == "Case name Day 2 of 3")), Times.Once);
             CommandHandlerMock.Verify(c => c.Handle(It.Is<CreateVideoHearingCommand>(c => c.ScheduledDateTime == request.Dates[1] && c.Cases[0].Name == "Case name Day 3 of 3")), Times.Once);
-            HearingServiceMock.Verify(h => h.UpdateHearingCaseName(It.Is<Guid>(g => g == hearingId), It.Is<string>(x => x == caseName)), Times.Once);
+            HearingServiceMock.Verify(h => h.RenameHearingForMultiDayBooking(It.Is<Guid>(g => g == hearingId), It.Is<string>(x => x == caseName)), Times.Once);
 
             EventPublisherMock.Verify(x => x.PublishAsync(It.IsAny<NewParticipantMultidayHearingConfirmationEvent>()), Times.Exactly(
                     hearing.Participants.Count(x => x is not Judge)));

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RenameHearingForMultiDayBooking.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RenameHearingForMultiDayBooking.cs
@@ -1,0 +1,60 @@
+using BookingsApi.Domain.Validations;
+namespace BookingsApi.UnitTests.Domain.Hearing
+{
+    public class RenameHearingForMultiDayBooking
+    {
+        [Test]
+        public void should_rename_hearing_for_multi_day_booking()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().WithCase().Build();
+            hearing.SourceId = Guid.NewGuid();
+            var existingCase = hearing.GetCases().FirstOrDefault();
+            var oldName = existingCase.Name;
+            var newName = $"{existingCase.Name} Day 1 of 3";
+
+            // Act
+            hearing.RenameHearingForMultiDayBooking(newName);
+            
+            // Assert
+            var updatedCase = hearing.GetCases().FirstOrDefault();
+            updatedCase.Name.Should().NotBe(oldName);
+            updatedCase.Name.Should().Be(newName);
+        }
+
+        [Test]
+        public void should_throw_exception_when_hearing_is_not_multi_day()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().WithCase().Build();
+            hearing.SourceId = null; // Not multi-day
+            var existingCase = hearing.GetCases().FirstOrDefault();
+            var oldName = existingCase.Name;
+            var newName = $"{existingCase.Name} Day 1 of 3";
+            
+            // Act
+            var action = () => hearing.RenameHearingForMultiDayBooking(newName);
+            
+            // Assert
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures
+                .Exists(x => x.Message == DomainRuleErrorMessages.HearingNotMultiDay).Should().BeTrue();
+            
+            var updatedCase = hearing.GetCases().FirstOrDefault();
+            updatedCase.Name.Should().Be(oldName);
+        }
+
+        [Test]
+        public void should_not_rename_hearing_when_hearing_has_no_cases()
+        {
+            // Arrange
+            var hearing = new VideoHearingBuilder().Build();
+            var newName = $"Test Day 1 of 3";
+
+            // Act
+            hearing.RenameHearingForMultiDayBooking(newName);
+            
+            // Assert
+            Assert.DoesNotThrow(() => hearing.RenameHearingForMultiDayBooking(newName));
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RenameHearingForMultiDayBooking.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RenameHearingForMultiDayBooking.cs
@@ -1,4 +1,5 @@
 using BookingsApi.Domain.Validations;
+
 namespace BookingsApi.UnitTests.Domain.Hearing
 {
     public class RenameHearingForMultiDayBooking

--- a/BookingsApi/BookingsApi/Controllers/V1/HearingsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/V1/HearingsController.cs
@@ -514,7 +514,7 @@ namespace BookingsApi.Controllers.V1
             }).ToList();
 
             var existingCase = videoHearing.GetCases()[0];
-            await _hearingService.UpdateHearingCaseName(hearingId, $"{existingCase.Name} Day {1} of {totalDays}");
+            await _hearingService.RenameHearingForMultiDayBooking(hearingId, $"{existingCase.Name} Day {1} of {totalDays}");
             var hearingsList = new List<VideoHearing>();
             foreach (var command in commands)
             {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10521


### Change description ###

- The Hearing domain method `UpdateCase` does not allow updates to a hearing that is due to start within 30 minutes. This rule needs to be bypassed as part of the multi-day hearing clone process (which renames them to Day 1 of 2, etc) so introduce a new a method - `RenameHearingForMultiDayBooking`
- Update tests to create the initial hearing with a status of Created
- Add a test for the 30 minute scenario