### PR TITLE
VIH-10566 Fixed broken Anonymisation query used in scheduler job

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Helper/SchedulerJobsNames.cs
+++ b/BookingsApi/BookingsApi.DAL/Helper/SchedulerJobsNames.cs
@@ -2,6 +2,6 @@ namespace BookingsApi.DAL.Helper
 {
     public static class SchedulerJobsNames
     {
-        public const string AnonymiseHearings = "AnonymiseHearingsConferencesAndDeleteAadUsersFunction";
+        public const string AnonymiseHearings = "AnonymiseHearingsConferencesAndDeleteAadUsersJob";
     }
 }

--- a/BookingsApi/BookingsApi.DAL/Queries/GetAnonymisationDataQuery.cs
+++ b/BookingsApi/BookingsApi.DAL/Queries/GetAnonymisationDataQuery.cs
@@ -3,43 +3,39 @@ using BookingsApi.DAL.Helper;
 
 namespace BookingsApi.DAL.Queries
 {
-    public class GetAnonymisationDataQuery : IQuery
-    {
-    }
+    public class GetAnonymisationDataQuery : IQuery { }
 
     public class GetAnonymisationDataQueryHandler : IQueryHandler<GetAnonymisationDataQuery, AnonymisationDataDto>
     {
         private readonly BookingsDbContext _context;
-        public GetAnonymisationDataQueryHandler(BookingsDbContext context)
-        {
-            _context = context;
-        }
-
+        public GetAnonymisationDataQueryHandler(BookingsDbContext context) =>_context = context;
         public async Task<AnonymisationDataDto> Handle(GetAnonymisationDataQuery query)
         {
+            //All hearings that have been scheduled before the last 3 months to be anonymised
             var cutOffDate = DateTime.UtcNow.AddMonths(-3);
             
+            //The last time this job ran successfully
             var lastRunDate = BaseQueries.JobHistory.GetLastRunDate(_context, SchedulerJobsNames.AnonymiseHearings);
 
+            //the date after which all hearings should be anonymised
             var cutOffDateFrom = lastRunDate.HasValue
                 ? cutOffDate.AddDays((lastRunDate.Value - DateTime.UtcNow).Days - 1)
-                : cutOffDate.AddDays(-30);
+                : DateTime.MinValue; //Run from the beginning of time, if the job has never run successfully before
 
+            //Persons that should be ignored from anonymisation due to being scheduled on future hearings (after the cutoff date)
             var personsInFutureHearings = _context.Participants
                 .Include(p => p.Person)
                 .Where(h => h.Hearing.ScheduledDateTime >= cutOffDate)
-                .Select(p => p.Person.Username).Distinct();
+                .Select(p => p.Person.Username)
+                .Distinct()
+                .AsQueryable();
 
             var participants = await _context.Participants
                 .Include(p => p.Person)
-                .Where(h => (h.Hearing.ScheduledDateTime >= cutOffDateFrom
-                             && h.Hearing.ScheduledDateTime < cutOffDate))
-                .Where(p => !personsInFutureHearings.Any(pf => pf == p.Person.Username))
-                .Where(p => !p.Person.Username.ToLower().EndsWith("@email.net"))
-                .Where(p => !p.Person.Username.ToLower().StartsWith("auto_vw"))
-                .Where(p => !p.Person.Username.ToLower().StartsWith("auto_sw"))
-                .Where(p => !p.Person.Username.ToLower().StartsWith("auto_tw"))
-                .Where(p => !p.Person.Username.ToLower().StartsWith("auto_aw"))
+                .Where(h => h.Hearing.ScheduledDateTime >= cutOffDateFrom && h.Hearing.ScheduledDateTime < cutOffDate)
+                .Where(p => personsInFutureHearings.All(pf => pf != p.Person.Username))
+                .Where(p => p.Person.Username.ToLower().EndsWith("@hearings.reform.hmcts.net"))
+                .Where(p => !p.Person.Username.ToLower().StartsWith("auto_"))
                 .ToListAsync();
 
             var usernameDto = new AnonymisationDataDto


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10566

### Change description ###
The route of the issue seems to be that we have the wrong name being checked in the job history, when setting the cutoff date for the anoymisation parameters. (The job name changed when we moved over to sds) So the scheduler job has been run over the same date on repeat for last year or so since we migrated to sds. This means nothing since has been anonymised. I've added the below changes which should resolve this. Will also need to update the production JobHistory table and set all previous runs under the new job name: IsSuccessful = to false, to recalibrate when the job should run from. 

1 - Updated JobName constant, so the correct job history is checked when setting the cutoff date; 
2 - Set to run from the beginning of time if no successful jobs found (needed to backdate all non-anonymised data); 
3 - Cleaned up query and made slightly more efficient to deal with larger payloads; 
4 - Added additional test scenario
