### PR TITLE
VIH-10637 Fix error updating hearings in group last minute

### DIFF
--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -315,7 +315,6 @@ namespace BookingsApi.Domain
         public JudiciaryParticipant UpdateJudiciaryParticipantByPersonalCode(string personalCode, string newDisplayName, 
             JudiciaryParticipantHearingRoleCode newHearingRoleCode)
         {
-            ValidateChangeAllowed(DomainRuleErrorMessages.CannotUpdateJudiciaryParticipantCloseToStartTime);
             if (!DoesJudiciaryParticipantExistByPersonalCode(personalCode))
             {
                 throw new DomainRuleException(nameof(personalCode), DomainRuleErrorMessages.JudiciaryParticipantNotFound);
@@ -331,6 +330,13 @@ namespace BookingsApi.Domain
             {
                 throw new InvalidOperationException($"{nameof(participant)} cannot be null");
             }
+            
+            var hasChanged = newDisplayName != participant.DisplayName ||
+                             newHearingRoleCode != participant.HearingRoleCode;
+            if (!hasChanged)
+                return participant;
+            
+            ValidateChangeAllowed(DomainRuleErrorMessages.CannotUpdateJudiciaryParticipantCloseToStartTime);
             
             participant.UpdateDisplayName(newDisplayName);
             participant.UpdateHearingRoleCode(newHearingRoleCode);

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingsInGroupV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingsInGroupV2Tests.cs
@@ -5,6 +5,7 @@ using BookingsApi.Contract.V2.Requests.Enums;
 using BookingsApi.DAL.Queries;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.Participants;
+using BookingsApi.Extensions;
 using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
 using BookingsApi.Infrastructure.Services.Publishers;
 using BookingsApi.Infrastructure.Services.ServiceBusQueue;
@@ -95,6 +96,10 @@ namespace BookingsApi.IntegrationTests.Api.V2.Hearings
                 requestHearing.JudiciaryParticipants.RemovedJudiciaryParticipantPersonalCodes.Add(judiciaryPanelMemberToRemove.PersonalCode);
                 requestHearing.JudiciaryParticipants.ExistingJudiciaryParticipants.Remove(judiciaryPanelMemberToRemove);
 
+                // Update a judiciary participant
+                var judiciaryPanelMemberToUpdate = requestHearing.JudiciaryParticipants.ExistingJudiciaryParticipants.First(jp => jp.HearingRoleCode == JudiciaryParticipantHearingRoleCodeV2.PanelMember);
+                judiciaryPanelMemberToUpdate.DisplayName += " EDITED";
+                
                 // Reassign a judge
                 requestHearing.JudiciaryParticipants.NewJudiciaryParticipants.Add(newJudiciaryJudge);
                 var judiciaryJudgeToReassign = requestHearing.JudiciaryParticipants.ExistingJudiciaryParticipants.First(jp => jp.HearingRoleCode == JudiciaryParticipantHearingRoleCodeV2.Judge);
@@ -710,6 +715,12 @@ namespace BookingsApi.IntegrationTests.Api.V2.Hearings
             foreach (var newJudiciaryParticipant in requestHearing.JudiciaryParticipants.NewJudiciaryParticipants)
             {
                 judiciaryParticipants.Should().Contain(p => p.JudiciaryPerson.PersonalCode == newJudiciaryParticipant.PersonalCode);
+            }
+            foreach (var judiciaryParticipant in requestHearing.JudiciaryParticipants.ExistingJudiciaryParticipants)
+            {
+                judiciaryParticipants.Should().Contain(p => p.JudiciaryPerson.PersonalCode == judiciaryParticipant.PersonalCode && 
+                                                            p.DisplayName == judiciaryParticipant.DisplayName && 
+                                                            p.HearingRoleCode == judiciaryParticipant.HearingRoleCode.MapToDomainEnum());
             }
             judiciaryParticipants.Should().NotContain(p => requestHearing.JudiciaryParticipants.RemovedJudiciaryParticipantPersonalCodes.Contains(p.JudiciaryPerson.PersonalCode));
             var newJudge = requestHearing.JudiciaryParticipants.NewJudiciaryParticipants.Find(jp => jp.HearingRoleCode == JudiciaryParticipantHearingRoleCodeV2.Judge);

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/UpdateJudiciaryParticipantTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/UpdateJudiciaryParticipantTests.cs
@@ -42,6 +42,23 @@ namespace BookingsApi.UnitTests.Domain.Hearing
                 .First(x => x.JudiciaryPerson.PersonalCode == judiciaryPanelMember.JudiciaryPerson.PersonalCode)
                 .DisplayName.Should().Be("New Display Name");
         }
+
+        [Test]
+        public void should_not_update_participant_when_no_changes_made()
+        {
+            var hearing = new VideoHearingBuilder(addJudge: false)
+                .WithJudiciaryJudge()
+                .Build();
+            var participant = hearing.GetJudiciaryParticipants()
+                .FirstOrDefault(x => x.HearingRoleCode == JudiciaryParticipantHearingRoleCode.Judge);
+            var updatedDateBefore = hearing.UpdatedDate;
+            
+            hearing.UpdateJudiciaryParticipantByPersonalCode(participant.JudiciaryPerson.PersonalCode, 
+                participant.DisplayName, participant.HearingRoleCode);
+
+            var updatedDateAfter = hearing.UpdatedDate;
+            updatedDateAfter.Should().Be(updatedDateBefore);
+        }
         
         [Test]
         public void Should_raise_exception_when_updating_judiciary_judge_to_panel_member_if_no_other_host_exists()

--- a/BookingsApi/BookingsApi/Services/UpdateHearingService.cs
+++ b/BookingsApi/BookingsApi/Services/UpdateHearingService.cs
@@ -117,8 +117,13 @@ namespace BookingsApi.Services
             foreach (var judiciaryParticipant in request.ExistingJudiciaryParticipants)
             {
                 // Only update the judiciary participant if their details have changed, to avoid inadvertently
-                // breaking the domain rule for last minute updates
+                // triggering a domain rule violation for last minute updates
                 var originalJudiciaryParticipant = hearing.JudiciaryParticipants.SingleOrDefault(x => x.JudiciaryPerson.PersonalCode == judiciaryParticipant.PersonalCode);
+                if (originalJudiciaryParticipant == null)
+                {
+                    // For consistency with the update participants functionality, non-existing judiciary participants are skipped in the update
+                    continue;
+                }
                 var judiciaryParticipantHasChanged = judiciaryParticipant.DisplayName != originalJudiciaryParticipant.DisplayName || 
                                                      judiciaryParticipant.HearingRoleCode.MapToDomainEnum() != originalJudiciaryParticipant.HearingRoleCode;
                 if (!judiciaryParticipantHasChanged)

--- a/BookingsApi/BookingsApi/Services/UpdateHearingService.cs
+++ b/BookingsApi/BookingsApi/Services/UpdateHearingService.cs
@@ -116,23 +116,15 @@ namespace BookingsApi.Services
 
             foreach (var judiciaryParticipant in request.ExistingJudiciaryParticipants)
             {
-                // Only update the judiciary participant if their details have changed, to avoid inadvertently
-                // triggering a domain rule violation for last minute updates
+                var judiciaryParticipantToUpdate = UpdateJudiciaryParticipantRequestV2ToUpdatedJudiciaryParticipantMapper.Map(
+                    judiciaryParticipant.PersonalCode, judiciaryParticipant);
+                
                 var originalJudiciaryParticipant = hearing.JudiciaryParticipants.SingleOrDefault(x => x.JudiciaryPerson.PersonalCode == judiciaryParticipant.PersonalCode);
                 if (originalJudiciaryParticipant == null)
                 {
                     // For consistency with the update participants functionality, non-existing judiciary participants are skipped in the update
                     continue;
                 }
-                var judiciaryParticipantHasChanged = judiciaryParticipant.DisplayName != originalJudiciaryParticipant.DisplayName || 
-                                                     judiciaryParticipant.HearingRoleCode.MapToDomainEnum() != originalJudiciaryParticipant.HearingRoleCode;
-                if (!judiciaryParticipantHasChanged)
-                {
-                    continue;
-                }
-                
-                var judiciaryParticipantToUpdate = UpdateJudiciaryParticipantRequestV2ToUpdatedJudiciaryParticipantMapper.Map(
-                    judiciaryParticipant.PersonalCode, judiciaryParticipant);
 
                 await _judiciaryParticipantService.UpdateJudiciaryParticipant(judiciaryParticipantToUpdate, hearing.Id);
             }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10637


### Change description ###
Fixes an error updating hearings in group last minute (30 minutes before a hearing starts)
The culprit is a domain rule which prevents updates to judiciary participants 30 minutes before the hearing starts. This rule is triggering even if there are not actually any edits being made to the judiciary participants.
To avoid this, don't attempt to update the judiciary participants if they have not actually changed.

- Update tests with additional coverage
- Add handling for participants in request not existing on hearing