### PR TITLE
VIH-10685 Prevent changing hearing dates to be same in multi day hearing

### DIFF
--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingsInGroupV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingsInGroupV2Tests.cs
@@ -2,15 +2,18 @@ using BookingsApi.Common;
 using BookingsApi.Contract.V2.Enums;
 using BookingsApi.Contract.V2.Requests;
 using BookingsApi.Contract.V2.Requests.Enums;
+using BookingsApi.DAL.Commands;
 using BookingsApi.DAL.Queries;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.Participants;
+using BookingsApi.Domain.Validations;
 using BookingsApi.Extensions;
 using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
 using BookingsApi.Infrastructure.Services.Publishers;
 using BookingsApi.Infrastructure.Services.ServiceBusQueue;
 using BookingsApi.Validations.V2;
 using FizzWare.NBuilder;
+using Testing.Common.Builders.Domain;
 
 namespace BookingsApi.IntegrationTests.Api.V2.Hearings
 {
@@ -607,6 +610,46 @@ namespace BookingsApi.IntegrationTests.Api.V2.Hearings
             var validationProblemDetails = await ApiClientResponse.GetResponses<ValidationProblemDetails>(result.Content);
             validationProblemDetails.Errors["Hearings[0]"][0].Should()
                 .Be($"Hearing venue code {request.Hearings[0].HearingVenueCode} does not exist");
+        }
+
+        [Test]
+        public async Task should_return_bad_request_when_a_scheduled_date_is_same_as_another_hearing_in_the_group_not_in_the_request()
+        {
+            // Scenario - day 1 of a multi-day hearing has been re-scheduled to a particular date. When subsequently updating the other days of the hearing as a group,
+            // they should not be allowed to be moved to the same date as the day 1 hearing
+            
+            // Arrange
+            var dates = new List<DateTime>
+            {
+                DateTime.Today.AddDays(14).AddHours(19).ToUniversalTime(),
+                DateTime.Today.AddDays(15).AddHours(19).ToUniversalTime(),
+                DateTime.Today.AddDays(16).AddHours(19).ToUniversalTime(),
+                DateTime.Today.AddDays(17).AddHours(19).ToUniversalTime(),
+                DateTime.Today.AddDays(18).AddHours(19).ToUniversalTime()
+            };
+            var hearings = await SeedHearingsInGroup(dates: dates);
+
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var day1Hearing = await db.VideoHearings.SingleAsync(h => h.Id == hearings[0].Id);
+            day1Hearing.SetProtected(nameof(day1Hearing.ScheduledDateTime), day1Hearing.ScheduledDateTime.AddDays(-7));
+            await db.SaveChangesAsync();
+
+            var request = BuildRequest();
+            request.Hearings = hearings.Where(h => h.Id != day1Hearing.Id).Select(MapHearingRequest).ToList();
+            request.Hearings[0].ScheduledDateTime = day1Hearing.ScheduledDateTime;
+            
+            var groupId = hearings[0].SourceId.Value;
+
+            // Act
+            using var client = Application.CreateClient();
+            var result = await client
+                .PatchAsync(ApiUriFactory.HearingsEndpointsV2.UpdateHearingsInGroupId(groupId),RequestBody.Set(request));
+
+            // Assert
+            result.IsSuccessStatusCode.Should().BeFalse();
+            result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var validationProblemDetails = await ApiClientResponse.GetResponses<ValidationProblemDetails>(result.Content);
+            validationProblemDetails.Errors["ScheduledDateTime"].Should().Contain(DomainRuleErrorMessages.CannotBeOnSameDateAsOtherHearingInGroup);
         }
         
         private static UpdateHearingsInGroupRequestV2 BuildRequest() =>

--- a/BookingsApi/BookingsApi/Validations/V2/UpdateHearingsInGroupRequestRefDataValidationV2.cs
+++ b/BookingsApi/BookingsApi/Validations/V2/UpdateHearingsInGroupRequestRefDataValidationV2.cs
@@ -15,6 +15,19 @@ namespace BookingsApi.Validations.V2
 
             RuleForEach(x => x.Hearings)
                 .SetValidator(new HearingRequestRefDataValidationV2(hearingRoles));
+            
+            RuleFor(x => x).Custom((request, context) =>
+            {
+                var hearingsInGroupNotInRequest = hearingsInGroup
+                    .Where(h => request.Hearings.TrueForAll(rh => rh.HearingId != h.Id))
+                    .ToList();
+
+                if (request.Hearings.Exists(rh => hearingsInGroupNotInRequest.Exists(h => h.ScheduledDateTime.Date == rh.ScheduledDateTime.Date)))
+                {
+                    context.AddFailure("ScheduledDateTime", 
+                        DomainRuleErrorMessages.CannotBeOnSameDateAsOtherHearingInGroup);
+                }
+            });
         }
 
         private static void ValidateHearing(HearingRequestV2 requestHearing, 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10685


### Change description ###
Extension of a previous ticket [(VIH-10537)](https://tools.hmcts.net/jira/browse/VIH-10537) - applies this validation rule to the multi-hearing edit

We validate in an earlier step to check whether any of the dates are the same for the hearings in the request. This adds an additional check against the existing hearings that are not in the request