### PR TITLE
VIH-10759 bug fix adding multiple endpoints in a single request

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Helper/CloneHearingToCommandMapper.cs
+++ b/BookingsApi/BookingsApi.DAL/Helper/CloneHearingToCommandMapper.cs
@@ -64,27 +64,13 @@ namespace BookingsApi.DAL.Helper
 
         private static List<NewEndpoint> GetNewEndpointsDtos(Hearing hearing, IRandomGenerator randomGenerator, string sipAddressStem)
         {
-            var newEndpoints = new List<NewEndpoint>();
-            foreach (var endpoint in hearing.GetEndpoints())
+            var endpointsToClone = hearing.GetEndpoints().Select(x => new NewEndpointRequestDto()
             {
-                string sip;
-                do
-                {
-                    sip = randomGenerator.GetWeakDeterministic(DateTime.UtcNow.Ticks, 1, 10);
-                } while (newEndpoints.Exists(x => x.Sip.StartsWith(sip)));
-                var pin = randomGenerator.GetWeakDeterministic(DateTime.UtcNow.Ticks, 1, 4);
-                var newEndpoint =  new NewEndpoint
-                {
-                    Pin = pin,
-                    Sip = $"{sip}{sipAddressStem}",
-                    DisplayName = endpoint.DisplayName,
-                    ContactEmail = endpoint.DefenceAdvocate?.Person?.ContactEmail
-                };
-            
-                newEndpoints.Add(newEndpoint);
-            }
+                DisplayName = x.DisplayName,
+                DefenceAdvocateContactEmail = x.DefenceAdvocate?.Person?.ContactEmail
+            }).ToList();
 
-            return newEndpoints;
+            return NewEndpointGenerator.GenerateNewEndpoints(endpointsToClone, randomGenerator, sipAddressStem);
         }
 
         private static List<LinkedParticipantDto> GetLinkedParticipantDtos(Hearing hearing)

--- a/BookingsApi/BookingsApi.DAL/Helper/NewEndpointGenerator.cs
+++ b/BookingsApi/BookingsApi.DAL/Helper/NewEndpointGenerator.cs
@@ -1,0 +1,44 @@
+using BookingsApi.Common.Services;
+using BookingsApi.DAL.Commands;
+
+namespace BookingsApi.DAL.Helper;
+
+/// <summary>
+/// Safely generate new endpoints for a hearing.
+/// The weak deterministic operation can cause issues on hardware that runs the loop too quickly.
+/// </summary>
+public static class NewEndpointGenerator
+{
+    public static List<NewEndpoint> GenerateNewEndpoints(List<NewEndpointRequestDto> endpointRequests,
+        IRandomGenerator randomGenerator, string sipAddressStem)
+    {
+        var endpoints = new List<NewEndpoint>();
+
+        foreach (var endpointRequest in endpointRequests)
+        {
+            string sip;
+
+            do
+            {
+                sip = randomGenerator.GetWeakDeterministic(DateTime.UtcNow.Ticks, 1, 10);
+            } while (endpoints.Exists(x => x.Sip.StartsWith(sip)));
+
+            var pin = randomGenerator.GetWeakDeterministic(DateTime.UtcNow.Ticks, 1, 4);
+            endpoints.Add(new NewEndpoint
+            {
+                Pin = pin,
+                Sip = $"{sip}{sipAddressStem}",
+                DisplayName = endpointRequest.DisplayName,
+                ContactEmail = endpointRequest.DefenceAdvocateContactEmail
+            });
+        }
+
+        return endpoints;
+    }
+}
+
+public class NewEndpointRequestDto
+{
+    public string DisplayName { get; set; }
+    public string DefenceAdvocateContactEmail { get; set; }
+}

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/BookNewHearingTests.cs
@@ -101,7 +101,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
         public async Task Should_successfully_book_hearing_without_endpoint()
         {
             var newRequest = RequestBuilderV1.Build();
-            newRequest.Endpoints = null;
+            newRequest.Endpoints = [];
             var response = await Controller.BookNewHearing(newRequest);
 
             response.Should().NotBeNull();

--- a/BookingsApi/BookingsApi/Mappings/V1/BookNewHearingRequestToCreateVideoHearingCommandMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V1/BookNewHearingRequestToCreateVideoHearingCommandMapper.cs
@@ -36,14 +36,12 @@ namespace BookingsApi.Mappings.V1
         private static List<NewEndpoint> MapEndpoints(BookNewHearingRequest request, IRandomGenerator randomGenerator,
             string sipAddressStem)
         {
-            var endpoints = new List<NewEndpoint>();
-            if (request.Endpoints != null)
+            var dtos = request.Endpoints.Select(x => new NewEndpointRequestDto()
             {
-                endpoints = request.Endpoints.Select(x =>
-                    EndpointToResponseMapper.MapRequestToNewEndpointDto(x, randomGenerator, sipAddressStem)).ToList();
-            }
-
-            return endpoints;
+                DisplayName = x.DisplayName,
+                DefenceAdvocateContactEmail = x.DefenceAdvocateContactEmail
+            }).ToList();
+            return NewEndpointGenerator.GenerateNewEndpoints(dtos, randomGenerator, sipAddressStem);
         }
 
         private static List<LinkedParticipantDto> MapLinkedParticipants(BookNewHearingRequest request)

--- a/BookingsApi/BookingsApi/Mappings/V2/BookNewHearingRequestV2ToCreateVideoHearingCommandMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/BookNewHearingRequestV2ToCreateVideoHearingCommandMapper.cs
@@ -43,14 +43,12 @@ public static class BookNewHearingRequestV2ToCreateVideoHearingCommandMapper
     private static List<NewEndpoint> MapEndpoints(BookNewHearingRequestV2 requestV2, IRandomGenerator randomGenerator,
         string sipAddressStem)
     {
-        var endpoints = new List<NewEndpoint>();
-        if (requestV2.Endpoints != null)
+        var dtos = requestV2.Endpoints.Select(x => new NewEndpointRequestDto()
         {
-            endpoints = requestV2.Endpoints.Select(x =>
-                EndpointToResponseV2Mapper.MapRequestToNewEndpointDto(x, randomGenerator, sipAddressStem)).ToList();
-        }
-
-        return endpoints;
+            DisplayName = x.DisplayName,
+            DefenceAdvocateContactEmail = x.DefenceAdvocateContactEmail
+        }).ToList();
+        return NewEndpointGenerator.GenerateNewEndpoints(dtos, randomGenerator, sipAddressStem);
     }
 
     private static List<LinkedParticipantDto> MapLinkedParticipants(BookNewHearingRequestV2 requestV2)


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10759 

### Change description ###

Introduce a NewEndpointGenerator.cs to capture SIPs with the same value during the same creation operation. As frameworks and hardware performance improves the ticks do not guarantee a reliable unique list of values when a request contains multiple endpoints.