### PR TITLE
VIH-11013 Add external reference id to participant and endpoint

### DIFF
--- a/BookingsApi/BookingsApi.Contract/V2/Requests/EndpointRequestV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Requests/EndpointRequestV2.cs
@@ -23,6 +23,16 @@ namespace BookingsApi.Contract.V2.Requests
         public string OtherLanguage { get; set; }
         
         /// <summary>
+        /// A unique identifier for the participant from an external system
+        /// </summary>
+        public string ExternalParticipantId { get; set; }
+        
+        /// <summary>
+        /// An external identifier for the special measure for the participant (optional)
+        /// </summary>
+        public string MeasuresExternalId { get; set; }
+        
+        /// <summary>
         ///    Screening requirements (special measure) for the endpoint (optional)
         /// </summary>
         public ScreeningRequest Screening { get; set; }

--- a/BookingsApi/BookingsApi.Contract/V2/Requests/ParticipantRequestV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Requests/ParticipantRequestV2.cs
@@ -69,6 +69,16 @@ namespace BookingsApi.Contract.V2.Requests
         public string OtherLanguage { get; set; }
         
         /// <summary>
+        /// A unique identifier for the participant from an external system
+        /// </summary>
+        public string ExternalParticipantId { get; set; }
+        
+        /// <summary>
+        /// An external identifier for the special measure for the participant (optional)
+        /// </summary>
+        public string MeasuresExternalId { get; set; }
+        
+        /// <summary>
         ///     Screening requirements (special measure) for the participant (optional)
         /// </summary>
         public ScreeningRequest Screening { get; set; }

--- a/BookingsApi/BookingsApi.Contract/V2/Requests/ScreeningRequest.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Requests/ScreeningRequest.cs
@@ -12,14 +12,9 @@ public class ScreeningRequest
     ///     Is the requirement for all participants or specific participants
     /// </summary>
     public ScreeningType Type { get; set; }
-
+    
     /// <summary>
-    ///     A list of participant contact emails to protect from
+    /// A list of entity external reference ids to protect from
     /// </summary>
-    public List<string> ProtectFromParticipants { get; set; } = [];
-
-    /// <summary>
-    ///     A list of endpoint display names to protect from
-    /// </summary>
-    public List<string> ProtectFromEndpoints { get; set; } = [];
+    public List<string> ProtectedFrom { get; set; } = [];
 }

--- a/BookingsApi/BookingsApi.Contract/V2/Requests/UpdateParticipantRequestV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Requests/UpdateParticipantRequestV2.cs
@@ -76,6 +76,16 @@ namespace BookingsApi.Contract.V2.Requests
         public ScreeningRequest Screening { get; set; }
         
         /// <summary>
+        /// A unique identifier for the participant from an external system
+        /// </summary>
+        public string ExternalParticipantId { get; set; }
+        
+        /// <summary>
+        /// An external identifier for the special measure for the participant (optional)
+        /// </summary>
+        public string MeasuresExternalId { get; set; }
+        
+        /// <summary>
         ///     List of linked participants
         /// </summary>
         public List<LinkedParticipantRequestV2> LinkedParticipants { get; set; }

--- a/BookingsApi/BookingsApi.Contract/V2/Responses/EndpointResponseV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Responses/EndpointResponseV2.cs
@@ -6,6 +6,7 @@ namespace BookingsApi.Contract.V2.Responses
     public class EndpointResponseV2
     {
         public Guid Id { get; set; }
+        public string ExternalReferenceId { get; set; }
         public string DisplayName { get; set; }
         public string Sip { get; set; }
         public string Pin { get; set; }

--- a/BookingsApi/BookingsApi.Contract/V2/Responses/EndpointResponseV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Responses/EndpointResponseV2.cs
@@ -6,7 +6,15 @@ namespace BookingsApi.Contract.V2.Responses
     public class EndpointResponseV2
     {
         public Guid Id { get; set; }
+        /// <summary>
+        /// The external reference id
+        /// </summary>
         public string ExternalReferenceId { get; set; }
+        
+        /// <summary>
+        /// An external identifier for the special measure for the participant (optional)
+        /// </summary>
+        public string MeasuresExternalId { get; set; }
         public string DisplayName { get; set; }
         public string Sip { get; set; }
         public string Pin { get; set; }

--- a/BookingsApi/BookingsApi.Contract/V2/Responses/ParticipantResponseV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Responses/ParticipantResponseV2.cs
@@ -17,6 +17,11 @@ namespace BookingsApi.Contract.V2.Responses
         public string ExternalReferenceId { get; set; }
         
         /// <summary>
+        /// An external identifier for the special measure for the participant (optional)
+        /// </summary>
+        public string MeasuresExternalId { get; set; }
+        
+        /// <summary>
         ///     Participant Display Name
         /// </summary>
         public string DisplayName { get; set; }

--- a/BookingsApi/BookingsApi.Contract/V2/Responses/ParticipantResponseV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Responses/ParticipantResponseV2.cs
@@ -12,6 +12,11 @@ namespace BookingsApi.Contract.V2.Responses
         public Guid Id { get; set; } 
         
         /// <summary>
+        /// The external reference id
+        /// </summary>
+        public string ExternalReferenceId { get; set; }
+        
+        /// <summary>
         ///     Participant Display Name
         /// </summary>
         public string DisplayName { get; set; }

--- a/BookingsApi/BookingsApi.Contract/V2/Responses/ScreeningResponseV2.cs
+++ b/BookingsApi/BookingsApi.Contract/V2/Responses/ScreeningResponseV2.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using BookingsApi.Contract.V2.Enums;
 
@@ -12,12 +11,7 @@ public class ScreeningResponseV2
     public ScreeningType Type { get; set; }
     
     /// <summary>
-    ///     A list of participant ids to be protected from
+    ///     A list of external references ids to be protected from
     /// </summary>
-    public List<Guid> ProtectFromParticipantsIds { get; set; } = [];
-    
-    /// <summary>
-    ///     A list of endpoint ids to be protected from
-    /// </summary>
-    public List<Guid> ProtectFromEndpointsIds { get; set; } = [];
+    public List<string> ProtectedFrom { get; set; } = [];
 }

--- a/BookingsApi/BookingsApi.DAL/Commands/AddEndPointToHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/AddEndPointToHearingCommand.cs
@@ -63,7 +63,10 @@ namespace BookingsApi.DAL.Commands
             var languages = await _context.InterpreterLanguages.Where(x => x.Live).ToListAsync();
             var dto = command.Endpoint;
             var defenceAdvocate = DefenceAdvocateHelper.CheckAndReturnDefenceAdvocate(dto.ContactEmail, hearing.GetParticipants());
-            var endpoint = new Endpoint(dto.ExternalParticipantId, dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate);
+            var endpoint = new Endpoint(dto.ExternalParticipantId, dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate)
+            {
+                MeasuresExternalId = dto.MeasuresExternalId
+            };
             var language = languages.GetLanguage(dto.LanguageCode, "Endpoint");
             endpoint.UpdateLanguagePreferences(language, dto.OtherLanguage);
             hearing.AddEndpoint(endpoint);

--- a/BookingsApi/BookingsApi.DAL/Commands/AddEndPointToHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/AddEndPointToHearingCommand.cs
@@ -14,6 +14,8 @@ namespace BookingsApi.DAL.Commands
         public string LanguageCode { get; set; }
         public string OtherLanguage { get; set; }
         public ScreeningDto Screening { get; set; }
+        public string ExternalParticipantId { get; set; }
+        public string MeasuresExternalId { get; set; }
     }
     
     public class AddEndPointToHearingCommand : ICommand
@@ -61,7 +63,7 @@ namespace BookingsApi.DAL.Commands
             var languages = await _context.InterpreterLanguages.Where(x => x.Live).ToListAsync();
             var dto = command.Endpoint;
             var defenceAdvocate = DefenceAdvocateHelper.CheckAndReturnDefenceAdvocate(dto.ContactEmail, hearing.GetParticipants());
-            var endpoint = new Endpoint(dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate);
+            var endpoint = new Endpoint(dto.ExternalParticipantId, dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate);
             var language = languages.GetLanguage(dto.LanguageCode, "Endpoint");
             endpoint.UpdateLanguagePreferences(language, dto.OtherLanguage);
             hearing.AddEndpoint(endpoint);

--- a/BookingsApi/BookingsApi.DAL/Commands/CreateVideoHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/CreateVideoHearingCommand.cs
@@ -104,7 +104,10 @@ namespace BookingsApi.DAL.Commands
                     var defenceAdvocate =
                         DefenceAdvocateHelper.CheckAndReturnDefenceAdvocate(dto.ContactEmail,
                             videoHearing.GetParticipants());
-                    var endpoint = new Endpoint(dto.ExternalParticipantId, dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate);
+                    var endpoint = new Endpoint(dto.ExternalParticipantId, dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate)
+                    {
+                        MeasuresExternalId = dto.MeasuresExternalId,
+                    };
                     var language = languages.GetLanguage(dto.LanguageCode, "Hearing");
                     endpoint.UpdateLanguagePreferences(language, dto.OtherLanguage);
                     newEndpoints.Add(endpoint);
@@ -121,7 +124,7 @@ namespace BookingsApi.DAL.Commands
             
             foreach (var participantForScreening in command.Participants.Where(x=> x.Screening != null))
             {
-                var participant = videoHearing.GetParticipants().Single(x=> x.Person.ContactEmail == participantForScreening.Person.ContactEmail);
+                var participant = videoHearing.GetParticipants().Single(x=> x.ExternalReferenceId == participantForScreening.ExternalReferenceId);
                 var screeningDto = participantForScreening.Screening;
                 _hearingService.UpdateParticipantScreeningRequirement(videoHearing, participant, screeningDto);
             }
@@ -129,7 +132,7 @@ namespace BookingsApi.DAL.Commands
             
             foreach (var endpointForScreening in (command.Endpoints ?? []).Where(x=> x.Screening != null))
             {
-                var endpoint = videoHearing.GetEndpoints().Single(x=> x.DisplayName == endpointForScreening.DisplayName);
+                var endpoint = videoHearing.GetEndpoints().Single(x=> x.ExternalReferenceId == endpointForScreening.ExternalParticipantId);
                 var screeningDto = endpointForScreening.Screening;
                 videoHearing.AssignScreeningForEndpoint(endpoint, screeningDto.ScreeningType, screeningDto.ProtectedFrom);
             }

--- a/BookingsApi/BookingsApi.DAL/Commands/CreateVideoHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/CreateVideoHearingCommand.cs
@@ -104,7 +104,7 @@ namespace BookingsApi.DAL.Commands
                     var defenceAdvocate =
                         DefenceAdvocateHelper.CheckAndReturnDefenceAdvocate(dto.ContactEmail,
                             videoHearing.GetParticipants());
-                    var endpoint = new Endpoint(dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate);
+                    var endpoint = new Endpoint(dto.ExternalParticipantId, dto.DisplayName, dto.Sip, dto.Pin, defenceAdvocate);
                     var language = languages.GetLanguage(dto.LanguageCode, "Hearing");
                     endpoint.UpdateLanguagePreferences(language, dto.OtherLanguage);
                     newEndpoints.Add(endpoint);
@@ -131,7 +131,7 @@ namespace BookingsApi.DAL.Commands
             {
                 var endpoint = videoHearing.GetEndpoints().Single(x=> x.DisplayName == endpointForScreening.DisplayName);
                 var screeningDto = endpointForScreening.Screening;
-                videoHearing.AssignScreeningForEndpoint(endpoint, screeningDto.ScreeningType, screeningDto.ProtectFromParticipants, screeningDto.ProtectFromEndpoints);
+                videoHearing.AssignScreeningForEndpoint(endpoint, screeningDto.ScreeningType, screeningDto.ProtectedFrom);
             }
             await _context.SaveChangesAsync();
             command.NewHearingId = videoHearing.Id;

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateEndPointOfHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateEndPointOfHearingCommand.cs
@@ -26,6 +26,11 @@ namespace BookingsApi.DAL.Commands
         public string LanguageCode { get; set; }
         public string OtherLanguage { get; set; }
         public ScreeningDto Screening { get; }
+        
+        /// <summary>
+        /// The updated endpoint entity
+        /// </summary>
+        public Endpoint UpdatedEndpoint { get; set; }
     }
 
     public class UpdateEndPointOfHearingCommandHandler : ICommandHandler<UpdateEndPointOfHearingCommand>
@@ -81,6 +86,8 @@ namespace BookingsApi.DAL.Commands
             
             _hearingService.UpdateEndpointScreeningRequirement(hearing, endpoint, command.Screening);
             await _context.SaveChangesAsync();
+
+            command.UpdatedEndpoint = endpoint;
         }
     }
 }

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateHearingParticipantsCommand.cs
@@ -115,6 +115,8 @@ namespace BookingsApi.DAL.Commands
 
                 var language = languages.GetLanguage(newExistingParticipantDetails.InterpreterLanguageCode, "Participant");
                 existingParticipant.UpdateLanguagePreferences(language, newExistingParticipantDetails.OtherLanguage);
+                existingParticipant.ExternalReferenceId = newExistingParticipantDetails.ExternalReferenceId;
+                existingParticipant.MeasuresExternalId = newExistingParticipantDetails.MeasuresExternalId;
             }
             
             hearing.UpdateBookingStatusJudgeRequirement();

--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateParticipantCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateParticipantCommand.cs
@@ -45,6 +45,8 @@ namespace BookingsApi.DAL.Commands
         public string InterpreterLanguageCode { get; set; }
         public string OtherLanguage { get; set; }
         public ScreeningDto Screening { get; set; }
+        public string ExternalReferenceId { get; set; }
+        public string MeasuresExternalId { get; set; }
 
         public UpdateParticipantCommand(UpdateParticipantCommandRequiredDto requiredDto, UpdateParticipantCommandOptionalDto optionalDto = null)
         {
@@ -62,6 +64,8 @@ namespace BookingsApi.DAL.Commands
             InterpreterLanguageCode = optionalDto?.InterpreterLanguageCode;
             OtherLanguage = optionalDto?.OtherLanguage;
             Screening = optionalDto?.Screening;
+            ExternalReferenceId = optionalDto?.ExternalReferenceId;
+            MeasuresExternalId = optionalDto?.MeasuresExternalId;
         }
     }
 
@@ -149,6 +153,8 @@ namespace BookingsApi.DAL.Commands
             var languages = await _context.InterpreterLanguages.Where(x=> x.Live).ToListAsync();
             var language = languages.GetLanguage(command.InterpreterLanguageCode, "Participant");
             participant.UpdateLanguagePreferences(language, command.OtherLanguage);
+            participant.ExternalReferenceId = command.ExternalReferenceId;
+            participant.MeasuresExternalId = command.MeasuresExternalId;
 
             _hearingService.UpdateParticipantScreeningRequirement(hearing, participant, command.Screening);
 

--- a/BookingsApi/BookingsApi.DAL/Dtos/ExistingParticipantDetails.cs
+++ b/BookingsApi/BookingsApi.DAL/Dtos/ExistingParticipantDetails.cs
@@ -17,4 +17,6 @@ public class ExistingParticipantDetails
     public string InterpreterLanguageCode { get; set; }
     public string OtherLanguage { get; set; }
     public ScreeningDto Screening { get; set; }
+    public string ExternalReferenceId { get; set; }
+    public string MeasuresExternalId { get; set; }
 }

--- a/BookingsApi/BookingsApi.DAL/Dtos/NewParticipant.cs
+++ b/BookingsApi/BookingsApi.DAL/Dtos/NewParticipant.cs
@@ -2,7 +2,12 @@ namespace BookingsApi.DAL.Dtos;
 
 public class NewParticipant
 {
+    public NewParticipant()
+    {
+        
+    }
     public Person Person { get; set; }
+    [Obsolete("CaseRole is no longer required. Will be removed in a future release")]
     public CaseRole CaseRole { get; set; }
     public HearingRole HearingRole { get; set; }
     public string Representee { get; set; }
@@ -10,4 +15,6 @@ public class NewParticipant
     public string InterpreterLanguageCode { get; set; }
     public string OtherLanguage { get; set; }
     public ScreeningDto Screening { get; set; }
+    public string ExternalReferenceId { get; set; }
+    public string MeasuresExternalId { get; set; }
 }

--- a/BookingsApi/BookingsApi.DAL/Dtos/NewParticipant.cs
+++ b/BookingsApi/BookingsApi.DAL/Dtos/NewParticipant.cs
@@ -2,10 +2,6 @@ namespace BookingsApi.DAL.Dtos;
 
 public class NewParticipant
 {
-    public NewParticipant()
-    {
-        
-    }
     public Person Person { get; set; }
     [Obsolete("CaseRole is no longer required. Will be removed in a future release")]
     public CaseRole CaseRole { get; set; }

--- a/BookingsApi/BookingsApi.DAL/Dtos/ScreeningDto.cs
+++ b/BookingsApi/BookingsApi.DAL/Dtos/ScreeningDto.cs
@@ -6,14 +6,9 @@ public class ScreeningDto
     /// Screening type (all or specific)
     /// </summary>
     public ScreeningType ScreeningType { get; set; }
-    
+
     /// <summary>
-    /// The contact emails of participants to screen from
+    /// The external reference id of entities to protect from
     /// </summary>
-    public List<string> ProtectFromParticipants { get; set; }
-    
-    /// <summary>
-    /// The display names of endpoints to screen from
-    /// </summary>
-    public List<string> ProtectFromEndpoints { get; set; }
+    public List<string> ProtectedFrom { get; set; } = [];
 }

--- a/BookingsApi/BookingsApi.DAL/Dtos/UpdateParticipantDto.cs
+++ b/BookingsApi/BookingsApi.DAL/Dtos/UpdateParticipantDto.cs
@@ -7,4 +7,4 @@ public record UpdateParticipantCommandRequiredDto(Guid HearingId, Guid Participa
     
 public record UpdateParticipantCommandOptionalDto(RepresentativeInformation RepresentativeInformation,
     AdditionalInformation AdditionalInformation, string ContactEmail, string InterpreterLanguageCode, string OtherLanguage,
-    ScreeningDto Screening);
+    ScreeningDto Screening, string ExternalReferenceId, string MeasuresExternalId);

--- a/BookingsApi/BookingsApi.DAL/Extensions/ScreeningExtensions.cs
+++ b/BookingsApi/BookingsApi.DAL/Extensions/ScreeningExtensions.cs
@@ -1,0 +1,24 @@
+using BookingsApi.DAL.Dtos;
+using BookingsApi.Domain.SpecialMeasure;
+
+namespace BookingsApi.DAL.Extensions;
+
+public static class ScreeningExtensions
+{
+    public static ScreeningDto MapToScreeningDto(this Screening screening)
+    {
+        if (screening == null)
+        {
+            return null;
+        }
+
+        var endpointIds = screening.GetEndpoints().Select(x => x.Endpoint.ExternalReferenceId).ToList();
+        var participantIds = screening.GetParticipants().Select(x => x.Participant.ExternalReferenceId).ToList();
+        
+        return new ScreeningDto
+        {
+            ScreeningType = screening.Type,
+            ProtectedFrom = endpointIds.Concat(participantIds).ToList()
+        };
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Helper/CloneHearingToCommandMapper.cs
+++ b/BookingsApi/BookingsApi.DAL/Helper/CloneHearingToCommandMapper.cs
@@ -27,6 +27,8 @@ namespace BookingsApi.DAL.Helper
             var participants = new List<NewParticipant>();
             participants.AddRange(reps.Select(r => new NewParticipant
             {
+                ExternalReferenceId = r.ExternalReferenceId,
+                MeasuresExternalId = r.MeasuresExternalId,
                 Person = r.Person,
                 Representee = r.Representee,
                 CaseRole = r.CaseRole,
@@ -35,6 +37,8 @@ namespace BookingsApi.DAL.Helper
             }));
             participants.AddRange(nonReps.Select(r => new NewParticipant
             {
+                ExternalReferenceId = r.ExternalReferenceId,
+                MeasuresExternalId = r.MeasuresExternalId,
                 Person = r.Person,
                 CaseRole = r.CaseRole,
                 DisplayName = r.DisplayName,

--- a/BookingsApi/BookingsApi.DAL/Helper/CloneHearingToCommandMapper.cs
+++ b/BookingsApi/BookingsApi.DAL/Helper/CloneHearingToCommandMapper.cs
@@ -2,6 +2,7 @@ using BookingsApi.Domain.Participants;
 using BookingsApi.Common.Services;
 using BookingsApi.DAL.Commands;
 using BookingsApi.DAL.Dtos;
+using BookingsApi.DAL.Extensions;
 
 namespace BookingsApi.DAL.Helper
 {
@@ -33,7 +34,8 @@ namespace BookingsApi.DAL.Helper
                 Representee = r.Representee,
                 CaseRole = r.CaseRole,
                 DisplayName = r.DisplayName,
-                HearingRole = r.HearingRole
+                HearingRole = r.HearingRole,
+                Screening = r.Screening.MapToScreeningDto()
             }));
             participants.AddRange(nonReps.Select(r => new NewParticipant
             {
@@ -42,7 +44,8 @@ namespace BookingsApi.DAL.Helper
                 Person = r.Person,
                 CaseRole = r.CaseRole,
                 DisplayName = r.DisplayName,
-                HearingRole = r.HearingRole
+                HearingRole = r.HearingRole,
+                Screening = r.Screening.MapToScreeningDto()
             }));
 
             var cases = hearing.GetCases().Select(c => new Case(c.Number, $"{c.Name} Day {hearingDay} of {totalDays}")
@@ -71,7 +74,10 @@ namespace BookingsApi.DAL.Helper
             var endpointsToClone = hearing.GetEndpoints().Select(x => new NewEndpointRequestDto()
             {
                 DisplayName = x.DisplayName,
-                DefenceAdvocateContactEmail = x.DefenceAdvocate?.Person?.ContactEmail
+                DefenceAdvocateContactEmail = x.DefenceAdvocate?.Person?.ContactEmail,
+                ExternalReferenceId = x.ExternalReferenceId,
+                MeasuresExternalId = x.MeasuresExternalId,
+                Screening = x.Screening.MapToScreeningDto(),
             }).ToList();
 
             return NewEndpointGenerator.GenerateNewEndpoints(endpointsToClone, randomGenerator, sipAddressStem);

--- a/BookingsApi/BookingsApi.DAL/Helper/NewEndpointGenerator.cs
+++ b/BookingsApi/BookingsApi.DAL/Helper/NewEndpointGenerator.cs
@@ -33,7 +33,9 @@ public static class NewEndpointGenerator
                 ContactEmail = endpointRequest.DefenceAdvocateContactEmail,
                 OtherLanguage = endpointRequest.OtherLanguage,
                 LanguageCode = endpointRequest.InterpreterLanguageCode,
-                Screening = endpointRequest.Screening
+                Screening = endpointRequest.Screening,
+                MeasuresExternalId = endpointRequest.MeasuresExternalId,
+                ExternalParticipantId = endpointRequest.ExternalReferenceId
             });
         }
 
@@ -43,6 +45,8 @@ public static class NewEndpointGenerator
 
 public class NewEndpointRequestDto
 {
+    public string ExternalReferenceId { get; set; }
+    public string MeasuresExternalId { get; set; }
     public string DisplayName { get; set; }
     public string DefenceAdvocateContactEmail { get; set; }
     public string InterpreterLanguageCode { get; set; }

--- a/BookingsApi/BookingsApi.DAL/Mappings/EndpointMap.cs
+++ b/BookingsApi/BookingsApi.DAL/Mappings/EndpointMap.cs
@@ -12,6 +12,8 @@ namespace BookingsApi.DAL.Mappings
             builder.Property(x => x.DisplayName).IsRequired();
             builder.HasIndex(x => x.Sip).IsUnique();
             builder.Property(x => x.Pin).IsRequired();
+            builder.Property(x=> x.ExternalReferenceId);
+            builder.Property(x => x.MeasuresExternalId);
             builder.HasOne<Hearing>("Hearing").WithMany("Endpoints").HasForeignKey(x => x.HearingId);
             builder.HasOne(x => x.DefenceAdvocate);
             builder.HasOne(x => x.InterpreterLanguage).WithMany().HasForeignKey(x => x.InterpreterLanguageId).IsRequired(false);

--- a/BookingsApi/BookingsApi.DAL/Mappings/ParticipantMap.cs
+++ b/BookingsApi/BookingsApi.DAL/Mappings/ParticipantMap.cs
@@ -15,6 +15,8 @@ namespace BookingsApi.DAL.Mappings
             builder.Property(x => x.DisplayName);
             builder.Property(x => x.CaseRoleId).IsRequired(false);
             builder.Property(x => x.HearingRoleId);
+            builder.Property(x=> x.ExternalReferenceId);
+            builder.Property(x => x.MeasuresExternalId);
             builder.HasOne(x => x.CaseRole).WithMany().HasForeignKey(x => x.CaseRoleId);
             builder.HasOne(x => x.HearingRole).WithMany().HasForeignKey(x => x.HearingRoleId);
             builder.HasOne<Hearing>("Hearing").WithMany("Participants").HasForeignKey(x => x.HearingId);

--- a/BookingsApi/BookingsApi.DAL/Migrations/20241004104511_AddExternalReferenceIdToParticipantAndEndpoint.Designer.cs
+++ b/BookingsApi/BookingsApi.DAL/Migrations/20241004104511_AddExternalReferenceIdToParticipantAndEndpoint.Designer.cs
@@ -4,6 +4,7 @@ using BookingsApi.DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookingsApi.DAL.Migrations
 {
     [DbContext(typeof(BookingsDbContext))]
-    partial class BookingsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241004104511_AddExternalReferenceIdToParticipantAndEndpoint")]
+    partial class AddExternalReferenceIdToParticipantAndEndpoint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookingsApi/BookingsApi.DAL/Migrations/20241004104511_AddExternalReferenceIdToParticipantAndEndpoint.cs
+++ b/BookingsApi/BookingsApi.DAL/Migrations/20241004104511_AddExternalReferenceIdToParticipantAndEndpoint.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookingsApi.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalReferenceIdToParticipantAndEndpoint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalReferenceId",
+                table: "Participant",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MeasuresExternalId",
+                table: "Participant",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalReferenceId",
+                table: "Endpoint",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MeasuresExternalId",
+                table: "Endpoint",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExternalReferenceId",
+                table: "Participant");
+
+            migrationBuilder.DropColumn(
+                name: "MeasuresExternalId",
+                table: "Participant");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalReferenceId",
+                table: "Endpoint");
+
+            migrationBuilder.DropColumn(
+                name: "MeasuresExternalId",
+                table: "Endpoint");
+        }
+    }
+}

--- a/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
+++ b/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
@@ -93,7 +93,7 @@ namespace BookingsApi.DAL.Services
                     case "Individual":
                         var individual = hearing.AddIndividual(participantToAdd.ExternalReferenceId, existingPerson ?? participantToAdd.Person, participantToAdd.HearingRole, participantToAdd.DisplayName);
                         individual.UpdateLanguagePreferences(language, participantToAdd.OtherLanguage);
-                        
+                        individual.MeasuresExternalId = participantToAdd.MeasuresExternalId;
                         UpdateOrganisationDetails(participantToAdd.Person, individual);
                         participantList.Add(individual);
                         break;
@@ -102,7 +102,7 @@ namespace BookingsApi.DAL.Services
                             var representative = hearing.AddRepresentative(participantToAdd.ExternalReferenceId, existingPerson ?? participantToAdd.Person,
                                 participantToAdd.HearingRole, participantToAdd.DisplayName, participantToAdd.Representee);
                             representative.UpdateLanguagePreferences(language, participantToAdd.OtherLanguage);
-
+                            representative.MeasuresExternalId = participantToAdd.MeasuresExternalId;
                             UpdateOrganisationDetails(participantToAdd.Person, representative);
                             participantList.Add(representative);
                             break;

--- a/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
+++ b/BookingsApi/BookingsApi.DAL/Services/HearingService.cs
@@ -91,8 +91,7 @@ namespace BookingsApi.DAL.Services
                 switch (participantToAdd.HearingRole.UserRole.Name)
                 {
                     case "Individual":
-                        var individual = hearing.AddIndividual(existingPerson ?? participantToAdd.Person, participantToAdd.HearingRole,
-                            participantToAdd.CaseRole, participantToAdd.DisplayName);
+                        var individual = hearing.AddIndividual(participantToAdd.ExternalReferenceId, existingPerson ?? participantToAdd.Person, participantToAdd.HearingRole, participantToAdd.DisplayName);
                         individual.UpdateLanguagePreferences(language, participantToAdd.OtherLanguage);
                         
                         UpdateOrganisationDetails(participantToAdd.Person, individual);
@@ -100,10 +99,8 @@ namespace BookingsApi.DAL.Services
                         break;
                     case "Representative":
                         {
-                            var representative = hearing.AddRepresentative(existingPerson ?? participantToAdd.Person,
-                                participantToAdd.HearingRole,
-                                participantToAdd.CaseRole, participantToAdd.DisplayName,
-                                participantToAdd.Representee);
+                            var representative = hearing.AddRepresentative(participantToAdd.ExternalReferenceId, existingPerson ?? participantToAdd.Person,
+                                participantToAdd.HearingRole, participantToAdd.DisplayName, participantToAdd.Representee);
                             representative.UpdateLanguagePreferences(language, participantToAdd.OtherLanguage);
 
                             UpdateOrganisationDetails(participantToAdd.Person, representative);
@@ -158,7 +155,7 @@ namespace BookingsApi.DAL.Services
             }
             
             var screeningExists = participant.Screening != null;
-            hearing.AssignScreeningForParticipant(participant, screeningDto.ScreeningType, screeningDto.ProtectFromParticipants, screeningDto.ProtectFromEndpoints);
+            hearing.AssignScreeningForParticipant(participant, screeningDto.ScreeningType, screeningDto.ProtectedFrom);
             // ef core does not automatically track entities created by domain methods
             _context.Entry(participant.Screening).State = screeningExists? EntityState.Modified : EntityState.Added;
             foreach (var screeningEntity in participant.Screening.ScreeningEntities)
@@ -179,7 +176,7 @@ namespace BookingsApi.DAL.Services
             }
             
             var screeningExists = endpoint.Screening != null;
-            hearing.AssignScreeningForEndpoint(endpoint, screeningDto.ScreeningType, screeningDto.ProtectFromParticipants, screeningDto.ProtectFromEndpoints);
+            hearing.AssignScreeningForEndpoint(endpoint, screeningDto.ScreeningType, screeningDto.ProtectedFrom);
             // ef core does not automatically track entities created by domain methods
             _context.Entry(endpoint.Screening).State = screeningExists? EntityState.Modified : EntityState.Added;
             foreach (var screeningEntity in endpoint.Screening.ScreeningEntities)

--- a/BookingsApi/BookingsApi.Domain/Endpoint.cs
+++ b/BookingsApi/BookingsApi.Domain/Endpoint.cs
@@ -19,18 +19,25 @@ namespace BookingsApi.Domain
         public int? InterpreterLanguageId { get; protected set; }
         public virtual InterpreterLanguage InterpreterLanguage { get; protected set; }
         public string OtherLanguage { get; set; }
-        
+        public string ExternalReferenceId { get; set; }
+        public string MeasuresExternalId { get; set; }
         public Guid? ScreeningId { get; set; }
         public virtual Screening Screening { get; set; }
 
         protected Endpoint(){}
 
+        [Obsolete("Use the constructor with externalParticipantId")]
         public Endpoint(string displayName, string sip, string pin, Participant defenceAdvocate)
         {
             DisplayName = displayName;
             Sip = sip;
             Pin = pin;
             DefenceAdvocate = defenceAdvocate;
+        }
+        
+        public Endpoint(string externalReferenceId, string displayName, string sip, string pin, Participant defenceAdvocate): this(displayName, sip, pin, defenceAdvocate)
+        {
+            ExternalReferenceId = externalReferenceId;
         }
 
         public void AssignDefenceAdvocate(Participant defenceAdvocate)

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -29,7 +29,7 @@ namespace BookingsApi.Domain
             Endpoints = new List<Endpoint>();
             Allocations = new List<Allocation>();
             JudiciaryParticipants = new List<JudiciaryParticipant>();
-            ConferenceSupplier = VideoSupplier.Kinly;
+            ConferenceSupplier = VideoSupplier.Vodafone;
         }
 
         /// <summary>

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -173,7 +173,10 @@ namespace BookingsApi.Domain
                 defenceAdvocate = Participants.Single(x => x.Id == endpoint.DefenceAdvocate.Id);
             }
 
-            var newEndpoint = new Endpoint(endpoint.ExternalReferenceId, endpoint.DisplayName, endpoint.Sip, endpoint.Pin, defenceAdvocate);
+            var newEndpoint = new Endpoint(endpoint.ExternalReferenceId, endpoint.DisplayName, endpoint.Sip, endpoint.Pin, defenceAdvocate)
+            {
+                MeasuresExternalId = endpoint.MeasuresExternalId
+            };
             newEndpoint.UpdateLanguagePreferences(endpoint.InterpreterLanguage, endpoint.OtherLanguage);
             Endpoints.Add(newEndpoint);
             UpdatedDate = DateTime.UtcNow;

--- a/BookingsApi/BookingsApi.Domain/Participants/Individual.cs
+++ b/BookingsApi/BookingsApi.Domain/Participants/Individual.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using BookingsApi.Domain.RefData;
 using BookingsApi.Domain.Validations;
@@ -10,10 +11,16 @@ namespace BookingsApi.Domain.Participants
         {
         }
 
+        [Obsolete("Use the constructor with the external reference id")]
         public Individual(Person person, HearingRole hearingRole, CaseRole caseRole) : base(person, hearingRole,
             caseRole)
         {
 
+        }
+
+        public Individual(string externalReferenceId, Person person, HearingRole hearingRole, string displayName) : base(
+            externalReferenceId, person, hearingRole, displayName)
+        {
         }
 
         protected override void ValidateParticipantDetails(string title, string displayName, string telephoneNumber, string organisationName)

--- a/BookingsApi/BookingsApi.Domain/Participants/Judge.cs
+++ b/BookingsApi/BookingsApi.Domain/Participants/Judge.cs
@@ -1,3 +1,4 @@
+using System;
 using BookingsApi.Domain.RefData;
 
 namespace BookingsApi.Domain.Participants
@@ -6,6 +7,7 @@ namespace BookingsApi.Domain.Participants
     {
         protected Judge() { }
 
+        [Obsolete("Judges are now JudiciaryParticipants")]
         public Judge(Person person, HearingRole hearingRole, CaseRole caseRole)
             : base(person, hearingRole, caseRole)
         {

--- a/BookingsApi/BookingsApi.Domain/Participants/JudicialOfficeHolder.cs
+++ b/BookingsApi/BookingsApi.Domain/Participants/JudicialOfficeHolder.cs
@@ -1,3 +1,4 @@
+using System;
 using BookingsApi.Domain.RefData;
 
 namespace BookingsApi.Domain.Participants
@@ -6,6 +7,7 @@ namespace BookingsApi.Domain.Participants
     {
         protected JudicialOfficeHolder() { }
         
+        [Obsolete("JudicialOfficeHolder are now JudiciaryParticipants")]
         public JudicialOfficeHolder(Person person, HearingRole hearingRole, CaseRole caseRole) : base(person, hearingRole,
             caseRole)
         {

--- a/BookingsApi/BookingsApi.Domain/Participants/Participant.cs
+++ b/BookingsApi/BookingsApi.Domain/Participants/Participant.cs
@@ -11,7 +11,7 @@ namespace BookingsApi.Domain.Participants
 {
     public abstract class Participant : ParticipantBase, IScreenableEntity
     {
-        protected readonly ValidationFailures _validationFailures = new ValidationFailures();
+        protected readonly ValidationFailures _validationFailures = new();
 
         protected Participant()
         {
@@ -20,6 +20,7 @@ namespace BookingsApi.Domain.Participants
             LinkedParticipants = new List<LinkedParticipant>();
         }
 
+        [Obsolete("Use the constructor with the external reference id")]
         protected Participant(Person person, HearingRole hearingRole, CaseRole caseRole) : this()
         {
             Person = person;
@@ -27,7 +28,14 @@ namespace BookingsApi.Domain.Participants
             HearingRoleId = hearingRole.Id;
             CaseRoleId = caseRole?.Id;
         }
-        
+
+        protected Participant(string externalReferenceId, Person person, HearingRole hearingRole, string displayName) :
+            this(person, hearingRole, null)
+        {
+            ExternalReferenceId = externalReferenceId;
+            DisplayName = displayName;
+        }
+
         public int? CaseRoleId { get; set; }
         public virtual CaseRole CaseRole { get; set; }
         public int HearingRoleId { get; set; }
@@ -40,6 +48,8 @@ namespace BookingsApi.Domain.Participants
         public DateTime UpdatedDate { get; set; }
         public string CreatedBy { get; set; }
         public string UpdatedBy { get; set; }
+        public string ExternalReferenceId { get; set; }
+        public string MeasuresExternalId { get; set; }
         public int? InterpreterLanguageId { get; protected set; }
         public virtual InterpreterLanguage InterpreterLanguage { get; protected set; }
         public string OtherLanguage { get; set; }

--- a/BookingsApi/BookingsApi.Domain/Participants/Representative.cs
+++ b/BookingsApi/BookingsApi.Domain/Participants/Representative.cs
@@ -11,9 +11,17 @@ namespace BookingsApi.Domain.Participants
         {
         }
 
+        [Obsolete("Use the constructor with the external reference id")]
         public Representative(Person person, HearingRole hearingRole, CaseRole caseRole) : base(person, hearingRole,
             caseRole)
         {
+        }
+        
+        public Representative(string externalReferenceId, Person person, HearingRole hearingRole, string displayName,
+            string representee) : base(
+            externalReferenceId, person, hearingRole, displayName)
+        {
+            Representee = representee;
         }
 
         public string Representee { get; set; }

--- a/BookingsApi/BookingsApi.Domain/RefData/CaseRole.cs
+++ b/BookingsApi/BookingsApi.Domain/RefData/CaseRole.cs
@@ -4,6 +4,7 @@ using BookingsApi.Domain.Enumerations;
 
 namespace BookingsApi.Domain.RefData
 {
+    [Obsolete("No longer required for a booking")]
     public class CaseRole : TrackableEntity<int>, IComparable
     {
         public CaseRole(int id, string name)

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/EndpointDto.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/EndpointDto.cs
@@ -6,6 +6,12 @@ namespace BookingsApi.Infrastructure.Services.Dtos
         public string Sip { get; set; }
         public string Pin { get; set; }
         public string DefenceAdvocateContactEmail { get; set; }
-        public string Role { get; set; }
+        public ConferenceRole Role { get; set; }
+    }
+
+    public enum ConferenceRole
+    {
+        Host,
+        Guest
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/EndpointDto.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/EndpointDto.cs
@@ -11,7 +11,7 @@ namespace BookingsApi.Infrastructure.Services.Dtos
 
     public enum ConferenceRole
     {
-        Host,
-        Guest
+        Host = 1,
+        Guest = 2
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/EndpointDto.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/EndpointDto.cs
@@ -6,5 +6,6 @@ namespace BookingsApi.Infrastructure.Services.Dtos
         public string Sip { get; set; }
         public string Pin { get; set; }
         public string DefenceAdvocateContactEmail { get; set; }
+        public string Role { get; set; }
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/HearingDto.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/HearingDto.cs
@@ -22,7 +22,7 @@ namespace BookingsApi.Infrastructure.Services.Dtos
 
     public enum ConferenceRoomType
     {
-        VMR,
-        VA
+        VMR = 1,
+        VA = 2
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/HearingDto.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/Dtos/HearingDto.cs
@@ -17,5 +17,12 @@ namespace BookingsApi.Infrastructure.Services.Dtos
         public string HearingType { get; set; }
         public string CaseTypeServiceId { get; set; }
         public VideoSupplier VideoSupplier { get; set; }
+        public ConferenceRoomType ConferenceRoomType { get; set; }
+    }
+
+    public enum ConferenceRoomType
+    {
+        VMR,
+        VA
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/EndpointDtoMapper.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/EndpointDtoMapper.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BookingsApi.Domain;
+using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.Participants;
 using BookingsApi.Infrastructure.Services.Dtos;
 
@@ -34,7 +35,8 @@ namespace BookingsApi.Infrastructure.Services
         /// <returns>'Host' or 'Guest'</returns>
         public static string GetEndpointConferenceRole(this Endpoint source, IList<Participant> participants, IList<Endpoint> endpoints)
         {
-            var requiresScreening = source.Screening != null && source.Screening.ScreeningEntities.Count > 0;
+            var requiresScreening = source.Screening != null && (source.Screening.Type == ScreeningType.All ||
+                                                                 source.Screening.ScreeningEntities.Count > 0);
             if (requiresScreening) return GuestRole;
 
             var participantScreenings = participants.Where(x => x.Screening != null).SelectMany(x => x.Screening.GetEndpoints()).ToList();

--- a/BookingsApi/BookingsApi.Infrastructure.Services/EndpointDtoMapper.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/EndpointDtoMapper.cs
@@ -1,19 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
 using BookingsApi.Domain;
+using BookingsApi.Domain.Participants;
 using BookingsApi.Infrastructure.Services.Dtos;
 
 namespace BookingsApi.Infrastructure.Services
 {
     public static class EndpointDtoMapper
     {
-        public static EndpointDto MapToDto(Endpoint source)
+        private const string HostRole = "Host";
+        private const string GuestRole = "Guest";
+            
+        public static EndpointDto MapToDto(Endpoint source, IList<Participant> participants, IList<Endpoint> endpoints)
         {
             return new EndpointDto
             {
                 DisplayName = source.DisplayName,
                 Sip = source.Sip,
                 Pin = source.Pin,
-                DefenceAdvocateContactEmail = source.DefenceAdvocate?.Person.ContactEmail
+                DefenceAdvocateContactEmail = source.DefenceAdvocate?.Person.ContactEmail,
+                Role = source.GetEndpointConferenceRole(participants, endpoints)
             };
+        }
+    
+    
+        /// <summary>
+        /// Determine the role of the endpoint in the conference. If an endpoint is screened from any participant or endpoint, it is a 'Guest'.
+        /// Otherwise, they are a 'Host'.
+        /// </summary>
+        /// <param name="source">Endpoint to check for screening requirements</param>
+        /// <param name="participants">List of participants to check if endpoint is being screened from</param>
+        /// <param name="endpoints">List of endpoints to check if endpoint is being screened from</param>
+        /// <returns>'Host' or 'Guest'</returns>
+        public static string GetEndpointConferenceRole(this Endpoint source, IList<Participant> participants, IList<Endpoint> endpoints)
+        {
+            var requiresScreening = source.Screening != null && source.Screening.ScreeningEntities.Count > 0;
+            if (requiresScreening) return GuestRole;
+
+            var participantScreenings = participants.Where(x => x.Screening != null).SelectMany(x => x.Screening.GetEndpoints()).ToList();
+            var endpointScreenings = endpoints.Where(x => x.Screening != null).SelectMany(x => x.Screening.GetEndpoints()).ToList();
+
+            var screenedFrom = participantScreenings.Exists(se => se.EndpointId == source.Id) ||
+                               endpointScreenings.Exists(se => se.EndpointId == source.Id);
+
+            return screenedFrom ? GuestRole : HostRole;
         }
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/EndpointDtoMapper.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/EndpointDtoMapper.cs
@@ -9,8 +9,6 @@ namespace BookingsApi.Infrastructure.Services
 {
     public static class EndpointDtoMapper
     {
-        private const string HostRole = "Host";
-        private const string GuestRole = "Guest";
             
         public static EndpointDto MapToDto(Endpoint source, IList<Participant> participants, IList<Endpoint> endpoints)
         {
@@ -33,11 +31,11 @@ namespace BookingsApi.Infrastructure.Services
         /// <param name="participants">List of participants to check if endpoint is being screened from</param>
         /// <param name="endpoints">List of endpoints to check if endpoint is being screened from</param>
         /// <returns>'Host' or 'Guest'</returns>
-        public static string GetEndpointConferenceRole(this Endpoint source, IList<Participant> participants, IList<Endpoint> endpoints)
+        public static ConferenceRole GetEndpointConferenceRole(this Endpoint source, IList<Participant> participants, IList<Endpoint> endpoints)
         {
             var requiresScreening = source.Screening != null && (source.Screening.Type == ScreeningType.All ||
                                                                  source.Screening.ScreeningEntities.Count > 0);
-            if (requiresScreening) return GuestRole;
+            if (requiresScreening) return ConferenceRole.Guest;
 
             var participantScreenings = participants.Where(x => x.Screening != null).SelectMany(x => x.Screening.GetEndpoints()).ToList();
             var endpointScreenings = endpoints.Where(x => x.Screening != null).SelectMany(x => x.Screening.GetEndpoints()).ToList();
@@ -45,7 +43,7 @@ namespace BookingsApi.Infrastructure.Services
             var screenedFrom = participantScreenings.Exists(se => se.EndpointId == source.Id) ||
                                endpointScreenings.Exists(se => se.EndpointId == source.Id);
 
-            return screenedFrom ? GuestRole : HostRole;
+            return screenedFrom ? ConferenceRole.Guest : ConferenceRole.Host;
         }
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/HearingDtoMapper.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/HearingDtoMapper.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using BookingsApi.Domain;
 using BookingsApi.Infrastructure.Services.Dtos;
 using BookingsApi.Domain.Constants;
@@ -8,6 +9,12 @@ namespace BookingsApi.Infrastructure.Services
     {
         public static HearingDto MapToDto(Hearing hearing)
         {
+            var roomType =
+                hearing.GetParticipants().Any(x => x.Screening != null) ||
+                hearing.GetEndpoints().Any(x => x.Screening != null)
+                    ? ConferenceRoomType.VA
+                    : ConferenceRoomType.VMR;
+            
             var @case = hearing.GetCases()[0];
             return new HearingDto
             {
@@ -22,7 +29,8 @@ namespace BookingsApi.Infrastructure.Services
                 RecordAudio = hearing.AudioRecordingRequired,
                 HearingType = hearing.HearingType?.Name,
                 CaseTypeServiceId = hearing.CaseType.ServiceId ?? RefData.DefaultCaseTypeServiceId,
-                VideoSupplier = hearing.ConferenceSupplier
+                VideoSupplier = hearing.ConferenceSupplier,
+                ConferenceRoomType = roomType
             };
         }
         

--- a/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/EndpointAddedIntegrationEvent.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/EndpointAddedIntegrationEvent.cs
@@ -6,10 +6,10 @@ namespace BookingsApi.Infrastructure.Services.IntegrationEvents.Events
 {
     public class EndpointAddedIntegrationEvent : IIntegrationEvent
     {
-        public EndpointAddedIntegrationEvent(Guid hearingId, Endpoint endpoint)
+        public EndpointAddedIntegrationEvent(Hearing hearing, Endpoint endpoint)
         {
-            HearingId = hearingId;
-            Endpoint = EndpointDtoMapper.MapToDto(endpoint);
+            HearingId = hearing.Id;
+            Endpoint = EndpointDtoMapper.MapToDto(endpoint, hearing.GetParticipants(), hearing.GetEndpoints());
         }
 
         public Guid HearingId { get; }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/EndpointUpdatedIntegrationEvent.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/EndpointUpdatedIntegrationEvent.cs
@@ -1,11 +1,12 @@
 using System;
+using BookingsApi.Infrastructure.Services.Dtos;
 
 namespace BookingsApi.Infrastructure.Services.IntegrationEvents.Events
 {
     public class EndpointUpdatedIntegrationEvent : IIntegrationEvent
     {
         public EndpointUpdatedIntegrationEvent(Guid hearingId, string sip, string displayName,
-            string defenceAdvocateContactEmail, string role)
+            string defenceAdvocateContactEmail, ConferenceRole role)
         {
             HearingId = hearingId;
             Sip = sip;
@@ -18,6 +19,6 @@ namespace BookingsApi.Infrastructure.Services.IntegrationEvents.Events
         public string Sip { get; }
         public string DisplayName { get; }
         public string DefenceAdvocate { get; }
-        public string Role { get; }
+        public ConferenceRole Role { get; }
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/EndpointUpdatedIntegrationEvent.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/EndpointUpdatedIntegrationEvent.cs
@@ -5,17 +5,19 @@ namespace BookingsApi.Infrastructure.Services.IntegrationEvents.Events
     public class EndpointUpdatedIntegrationEvent : IIntegrationEvent
     {
         public EndpointUpdatedIntegrationEvent(Guid hearingId, string sip, string displayName,
-            string defenceAdvocateContactEmail)
+            string defenceAdvocateContactEmail, string role)
         {
             HearingId = hearingId;
             Sip = sip;
             DisplayName = displayName;
             DefenceAdvocate = defenceAdvocateContactEmail;
+            Role = role;
         }
-
+        
         public Guid HearingId { get; }
         public string Sip { get; }
         public string DisplayName { get; }
         public string DefenceAdvocate { get; }
+        public string Role { get; }
     }
 }

--- a/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/HearingIsReadyForVideoIntegrationEvent.cs
+++ b/BookingsApi/BookingsApi.Infrastructure.Services/IntegrationEvents/Events/HearingIsReadyForVideoIntegrationEvent.cs
@@ -29,7 +29,8 @@ namespace BookingsApi.Infrastructure.Services.IntegrationEvents.Events
 
             Participants.SingleOrDefault(x => x.UserRole == "Judge")?.SetOtherFieldsForNonEJudJudgeUser(hearing.OtherInformation);
             var hearingEndpoints = hearing.GetEndpoints();
-            Endpoints = hearingEndpoints.Select(EndpointDtoMapper.MapToDto).ToList();
+            Endpoints = hearingEndpoints.Select(he =>
+                EndpointDtoMapper.MapToDto(he, hearing.GetParticipants(), hearing.GetEndpoints())).ToList();
             
             Func<Participant, bool> ParticipantHasContactEmail()
             {

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Endpoints/AddEndPointToHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Endpoints/AddEndPointToHearingTests.cs
@@ -113,7 +113,7 @@ public class AddEndPointToHearingTests : ApiTest
         });
         var serviceBusStub = Application.Services.GetService(typeof(IServiceBusQueueClient)) as ServiceBusQueueClientFake;
         var message = serviceBusStub!.ReadMessageFromQueue();
-        message.IntegrationEvent.Should().BeEquivalentTo(new EndpointAddedIntegrationEvent(hearingId,endpoint));
+        message.IntegrationEvent.Should().BeEquivalentTo(new EndpointAddedIntegrationEvent(seededHearing,endpoint));
     }
 
     [Test]

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/RemoveJudiciaryParticipantFromHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/RemoveJudiciaryParticipantFromHearingTests.cs
@@ -97,8 +97,7 @@ public class RemoveJudiciaryParticipantFromHearingTests : ApiTest
         await using var db = new BookingsDbContext(BookingsDbContextOptions);
         var hearingFromDb = await db.VideoHearings.Include(x => x.JudiciaryParticipants)
             .ThenInclude(x => x.JudiciaryPerson).FirstAsync(x => x.Id == hearingId);
-
-
+        
         hearingFromDb.GetJudiciaryParticipants()
             .Any(p => p.JudiciaryPerson.PersonalCode == judiciaryParticipant.JudiciaryPerson.PersonalCode)
             .Should()
@@ -112,5 +111,37 @@ public class RemoveJudiciaryParticipantFromHearingTests : ApiTest
         message.IntegrationEvent
             .Should()
             .BeEquivalentTo(new ParticipantRemovedIntegrationEvent(hearingId, judiciaryParticipant.Id));
+    }
+    
+    [Test]
+    public async Task should_remove_a_judge_from_the_confirmed_hearing()
+    {
+        // arrange
+        var hearing = await Hooks.SeedVideoHearingV2(options
+            => { options.Case = new Case("UpdateParticipantsRemoveParticipant", "UpdateParticipantsRemoveParticipant"); }, BookingStatus.Created);
+        var judge = hearing.GetJudiciaryParticipants().First(e => e.HearingRoleCode == JudiciaryParticipantHearingRoleCode.Judge);
+        
+        // Act
+        using var client = Application.CreateClient();
+        var result =
+            await client.DeleteAsync(
+                ApiUriFactory.JudiciaryParticipantEndpoints.RemoveJudiciaryParticipantFromHearing(hearing.Id,
+                    judge.JudiciaryPerson.PersonalCode));
+        
+        
+        // assert
+        result.IsSuccessStatusCode.Should().BeTrue();
+        result.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        
+        await using var db = new BookingsDbContext(BookingsDbContextOptions);
+        var hearingFromDb = await db.VideoHearings.Include(x => x.JudiciaryParticipants)
+            .ThenInclude(x => x.JudiciaryPerson).FirstAsync(x => x.Id == hearing.Id);
+        
+        hearingFromDb.GetJudiciaryParticipants()
+            .Any(p => p.JudiciaryPerson.PersonalCode == judge.JudiciaryPerson.PersonalCode)
+            .Should()
+            .BeFalse();
+
+        hearingFromDb.Status.Should().Be(BookingStatus.ConfirmedWithoutJudge);
     }
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/RemoveJudiciaryParticipantFromHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/JudiciaryParticipants/RemoveJudiciaryParticipantFromHearingTests.cs
@@ -106,7 +106,7 @@ public class RemoveJudiciaryParticipantFromHearingTests : ApiTest
         var serviceBusStub = Application.Services
             .GetService(typeof(IServiceBusQueueClient)) as ServiceBusQueueClientFake;
         var message = serviceBusStub!
-            .ReadMessageFromQueue();
+            .ReadAllMessagesFromQueue(hearingId)[0];
         
         message.IntegrationEvent
             .Should()

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Endpoints/AddEndPointToHearingV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Endpoints/AddEndPointToHearingV2Tests.cs
@@ -92,14 +92,13 @@ public class AddEndPointToHearingV2Tests : ApiTest
         using var client = Application.CreateClient();
         var bookingsApiClient = BookingsApiClient.GetClient(client);
 
-        var request = new EndpointRequestV2()
+        var request = new EndpointRequestV2
         {
             DisplayName = "add-endpoint",
-            Screening = new ScreeningRequest()
+            Screening = new ScreeningRequest
             {
                 Type = ScreeningType.Specific,
-                ProtectFromEndpoints = [endpoint.DisplayName],
-                ProtectFromParticipants = [individual.Person.ContactEmail]
+                ProtectedFrom = [endpoint.ExternalReferenceId, individual.ExternalReferenceId]
             }
         };
         
@@ -111,7 +110,6 @@ public class AddEndPointToHearingV2Tests : ApiTest
         response.DisplayName.Should().Be(request.DisplayName);
         response.Screening.Should().NotBeNull();
         response.Screening.Type.Should().Be(request.Screening.Type);
-        response.Screening.ProtectFromParticipantsIds.Should().BeEquivalentTo([individual.Id]);
-        response.Screening.ProtectFromEndpointsIds.Should().BeEquivalentTo([endpoint.Id]);
+        response.Screening.ProtectedFrom.Should().BeEquivalentTo(endpoint.ExternalReferenceId, individual.ExternalReferenceId);
     }
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Endpoints/UpdateEndpointV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Endpoints/UpdateEndpointV2Tests.cs
@@ -2,6 +2,7 @@ using BookingsApi.Client;
 using BookingsApi.Contract.V2.Requests;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.Participants;
+using BookingsApi.Infrastructure.Services.Dtos;
 using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
 using BookingsApi.Infrastructure.Services.ServiceBusQueue;
 using ScreeningType = BookingsApi.Contract.V2.Enums.ScreeningType;
@@ -136,10 +137,10 @@ public class UpdateEndpointV2Tests : ApiTest
         
         var updateEndpointEvents = messages.Where(x=> x. IntegrationEvent is EndpointUpdatedIntegrationEvent).ToList();
         var firstUpdateEvent = updateEndpointEvents[0].IntegrationEvent as EndpointUpdatedIntegrationEvent;
-        firstUpdateEvent!.Role.Should().Be("Guest", "Endpoint is screened from a participant");
+        firstUpdateEvent!.Role.Should().Be(ConferenceRole.Guest, "Endpoint is screened from a participant");
         
         var secondUpdateEvent = updateEndpointEvents[1].IntegrationEvent as EndpointUpdatedIntegrationEvent;
-        secondUpdateEvent!.Role.Should().Be("Host", "Endpoint is not screened from any participant");
+        secondUpdateEvent!.Role.Should().Be(ConferenceRole.Host, "Endpoint is not screened from any participant");
 
     }
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Endpoints/UpdateEndpointV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Endpoints/UpdateEndpointV2Tests.cs
@@ -99,7 +99,7 @@ public class UpdateEndpointV2Tests : ApiTest
             Screening = new ScreeningRequest()
             {
                 Type = ScreeningType.Specific,
-                ProtectFromParticipants = [screenFrom.Person.ContactEmail]
+                ProtectedFrom = [screenFrom.ExternalReferenceId]
             }
         };
         using var client = Application.CreateClient();

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/HearingLists/GetHearingsForTodayByCsosTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/HearingLists/GetHearingsForTodayByCsosTests.cs
@@ -27,11 +27,11 @@ public class GetHearingsForTodayByCsosTests : ApiTest
     public async Task should_return_hearings_allocated_to_cso_ids()
     {
         // arrange
-        var hearing = await Hooks.SeedVideoHearing(status:BookingStatus.Created, configureOptions: options =>
+        var hearing = await Hooks.SeedVideoHearingV2(status:BookingStatus.Created, configureOptions: options =>
         {
             options.ScheduledDate = DateTime.UtcNow;
         });
-        var hearingUnallocated = await Hooks.SeedVideoHearing(status:BookingStatus.Created, configureOptions: options =>
+        var hearingUnallocated = await Hooks.SeedVideoHearingV2(status:BookingStatus.Created, configureOptions: options =>
         {
             options.ScheduledDate = DateTime.UtcNow;
         });
@@ -60,14 +60,14 @@ public class GetHearingsForTodayByCsosTests : ApiTest
     public async Task should_return_unallocated_hearings()
     {
         // arrange
-        var hearing = await Hooks.SeedVideoHearing(status:BookingStatus.Created, configureOptions: options =>
+        var hearing = await Hooks.SeedVideoHearingV2(status:BookingStatus.Created, configureOptions: options =>
         {
             options.ScheduledDate = DateTime.UtcNow;
         });
         var justiceUser = await Hooks.SeedJusticeUser("user@test.com", "Test", "User");
         await Hooks.AddAllocation(hearing, justiceUser);
 
-        var hearingUnallocated = await Hooks.SeedVideoHearing(status:BookingStatus.Created, configureOptions: options =>
+        var hearingUnallocated = await Hooks.SeedVideoHearingV2(status:BookingStatus.Created, configureOptions: options =>
         {
             options.ScheduledDate = DateTime.UtcNow;
         });
@@ -90,13 +90,13 @@ public class GetHearingsForTodayByCsosTests : ApiTest
     public async Task should_return_hearings_allocated_to_cso_and_unallocated_hearings()
     {
         // arrange
-        var hearing = await Hooks.SeedVideoHearing(status: BookingStatus.Created,
+        var hearing = await Hooks.SeedVideoHearingV2(status: BookingStatus.Created,
             configureOptions: options => { options.ScheduledDate = DateTime.UtcNow; });
         var justiceUser = await Hooks.SeedJusticeUser("user@test.com", "Test", "User");
         await Hooks.AddAllocation(hearing, justiceUser);
         var csoIds = new List<Guid> {justiceUser.Id};
 
-        var hearingUnallocated = await Hooks.SeedVideoHearing(status: BookingStatus.Created,
+        var hearingUnallocated = await Hooks.SeedVideoHearingV2(status: BookingStatus.Created,
             configureOptions: options => { options.ScheduledDate = DateTime.UtcNow; });
         var request = new HearingsForTodayByAllocationRequestV2 { CsoIds = csoIds, Unallocated = true };
 

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/HearingParticipants/AddParticipantsToHearingV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/HearingParticipants/AddParticipantsToHearingV2Tests.cs
@@ -116,7 +116,7 @@ public class AddParticipantsToHearingV2Tests : ApiTest
         request.Participants[0].Screening = new ScreeningRequest()
         {
             Type = ScreeningType.Specific,
-            ProtectFromEndpoints = [hearing.Endpoints[0].DisplayName]
+            ProtectedFrom = [hearing.Endpoints[0].ExternalReferenceId]
         };
 
         // act
@@ -137,7 +137,7 @@ public class AddParticipantsToHearingV2Tests : ApiTest
         addedParticipant.Should().NotBeNull();
         addedParticipant.Screening.Should().NotBeNull();
         addedParticipant.Screening.Type.Should().Be(ScreeningType.Specific);
-        addedParticipant.Screening.ProtectFromEndpointsIds.Should().Contain(hearing.Endpoints[0].Id);
+        addedParticipant.Screening.ProtectedFrom.Should().Contain(hearing.Endpoints[0].ExternalReferenceId);
     }
     
     private static AddParticipantsToHearingRequestV2 BuildRequestObject()

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/HearingParticipants/UpdateParticipantDetailsV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/HearingParticipants/UpdateParticipantDetailsV2Tests.cs
@@ -164,7 +164,7 @@ public class UpdateParticipantDetailsV2Tests : ApiTest
     [TestCase("Test-Judge  1", false)]
     public async Task should_return_validation_error_when_first_last_names_are_not_valid(string testName, bool expectedResult)
     {
-        var hearing = await Hooks.SeedVideoHearing(status:BookingStatus.Booked);
+        var hearing = await Hooks.SeedVideoHearingV2(status:BookingStatus.Booked);
         var hearingId = hearing.Id;
         var participant = hearing.GetParticipants().First(x=> x is Individual);
         var participantId = participant.Id;
@@ -207,7 +207,7 @@ public class UpdateParticipantDetailsV2Tests : ApiTest
     [Test]
     public async Task should_not_update_middle_names_when_middle_names_not_provided()
     {
-        var hearing = await Hooks.SeedVideoHearing(status:BookingStatus.Created);
+        var hearing = await Hooks.SeedVideoHearingV2(status:BookingStatus.Created);
         var hearingId = hearing.Id;
         var participant = hearing.GetParticipants().First(x=> x is Individual);
         var participantId = participant.Id;
@@ -549,8 +549,7 @@ public class UpdateParticipantDetailsV2Tests : ApiTest
             Screening = new ScreeningRequest
             {
                 Type = ScreeningType.Specific,
-                ProtectFromParticipants = [secondParticipant.Person.ContactEmail],
-                ProtectFromEndpoints = [endpointForScreening.DisplayName]
+                ProtectedFrom = [secondParticipant.ExternalReferenceId, endpointForScreening.ExternalReferenceId]
             }
         };
         
@@ -567,7 +566,6 @@ public class UpdateParticipantDetailsV2Tests : ApiTest
         var participantResponse = await ApiClientResponse.GetResponses<ParticipantResponseV2>(result.Content);
         participantResponse.Screening.Should().NotBeNull();
         participantResponse.Screening.Type.Should().Be(ScreeningType.Specific);
-        participantResponse.Screening.ProtectFromParticipantsIds.Should().Contain(secondParticipant.Id);
-        participantResponse.Screening.ProtectFromEndpointsIds.Should().Contain(endpointForScreening.Id);
+        participantResponse.Screening.ProtectedFrom.Should().Contain(secondParticipant.ExternalReferenceId);
     }
 }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
@@ -71,7 +71,7 @@ public class BookNewHearingV2Tests : ApiTest
         var hearingReadyEvent = messages.First(x => x.IntegrationEvent is HearingIsReadyForVideoIntegrationEvent);
         var integrationEvent = hearingReadyEvent.IntegrationEvent as HearingIsReadyForVideoIntegrationEvent;
         integrationEvent!.Hearing.ConferenceRoomType.Should().Be(ConferenceRoomType.VMR);
-        integrationEvent.Endpoints[0].Role.Should().Be("Host");
+        integrationEvent.Endpoints[0].Role.Should().Be(ConferenceRole.Host);
     }
     
     [Test]
@@ -299,7 +299,7 @@ public class BookNewHearingV2Tests : ApiTest
         var integrationEvent = messages.First(x => x.IntegrationEvent is HearingIsReadyForVideoIntegrationEvent);
         var hearingIsReadyEvent = integrationEvent.IntegrationEvent as HearingIsReadyForVideoIntegrationEvent;
         hearingIsReadyEvent!.Hearing.ConferenceRoomType.Should().Be(ConferenceRoomType.VA);
-        hearingIsReadyEvent.Endpoints[0].Role.Should().Be("Guest");
+        hearingIsReadyEvent.Endpoints[0].Role.Should().Be(ConferenceRole.Guest);
     }
     
      [Test]

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
@@ -242,8 +242,7 @@ public class BookNewHearingV2Tests : ApiTest
         participantWithSpecificScreening.Screening = new ScreeningRequest
         {
             Type = ScreeningType.Specific,
-            ProtectFromParticipants = [protectedFrom.ContactEmail],
-            ProtectFromEndpoints = [endpoint.DisplayName]
+            ProtectedFrom = [protectedFrom.ExternalParticipantId, endpoint.ExternalParticipantId]
         };
         
         // act
@@ -272,8 +271,8 @@ public class BookNewHearingV2Tests : ApiTest
         var protectFromResponse = createdResponse.Participants.Find(x => x.ContactEmail == protectedFrom.ContactEmail);
         var endpointResponse = createdResponse.Endpoints.Find(x => x.DisplayName == endpoint.DisplayName);
         
-        actual.ProtectFromEndpointsIds.Should().Contain(endpointResponse.Id);
-        actual.ProtectFromParticipantsIds.Should().Contain(protectFromResponse.Id);
+        actual.ProtectedFrom.Should().Contain(endpointResponse.ExternalReferenceId);
+        actual.ProtectedFrom.Should().Contain(protectFromResponse.ExternalReferenceId);
     }
     
      [Test]
@@ -294,8 +293,7 @@ public class BookNewHearingV2Tests : ApiTest
         participantWithSpecificScreening.Screening = new ScreeningRequest
         {
             Type = ScreeningType.Specific,
-            ProtectFromParticipants = ["does-not-exist"],
-            ProtectFromEndpoints = ["made-up"]
+            ProtectedFrom = ["does-not-exist", "made-up"]
         };
         
         // act
@@ -330,8 +328,7 @@ public class BookNewHearingV2Tests : ApiTest
         endpoint.Screening = new ScreeningRequest
         {
             Type = ScreeningType.Specific,
-            ProtectFromParticipants = [protectedFrom.ContactEmail],
-            ProtectFromEndpoints = [endpoint2.DisplayName]
+            ProtectedFrom = [protectedFrom.ExternalParticipantId, endpoint2.ExternalParticipantId]
         };
         
         // act
@@ -360,8 +357,8 @@ public class BookNewHearingV2Tests : ApiTest
         var protectFromResponse = createdResponse.Participants.Find(x => x.ContactEmail == protectedFrom.ContactEmail);
         var endpointResponse = createdResponse.Endpoints.Find(x => x.DisplayName == endpoint2.DisplayName);
         
-        actual.ProtectFromEndpointsIds.Should().Contain(endpointResponse.Id);
-        actual.ProtectFromParticipantsIds.Should().Contain(protectFromResponse.Id);
+        actual.ProtectedFrom.Should().Contain(endpointResponse.ExternalReferenceId);
+        actual.ProtectedFrom.Should().Contain(protectFromResponse.ExternalReferenceId);
     }
     
     [Test]

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
@@ -314,11 +314,13 @@ public class BookNewHearingV2Tests : ApiTest
         
         var endpoint = new EndpointRequestV2
         {
-            DisplayName = "Endpoint A"
+            DisplayName = "Endpoint A",
+            ExternalParticipantId = Guid.NewGuid().ToString()
         };
         var endpoint2 = new EndpointRequestV2
         {
-            DisplayName = "Endpoint B"
+            DisplayName = "Endpoint B",
+            ExternalParticipantId = Guid.NewGuid().ToString()
         };
         request.Endpoints.AddRange([endpoint, endpoint2]);
         

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/BookNewHearingV2Tests.cs
@@ -231,7 +231,8 @@ public class BookNewHearingV2Tests : ApiTest
         
         var endpoint = new EndpointRequestV2
         {
-            DisplayName = "Endpoint A"
+            DisplayName = "Endpoint A",
+            ExternalParticipantId = Guid.NewGuid().ToString()
         };
         request.Endpoints.Add(endpoint);
         

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/CloneHearingTests.cs
@@ -91,6 +91,7 @@ public class CloneHearingTests : ApiTest
         result.IsSuccessStatusCode.Should().BeTrue();
         result.StatusCode.Should().Be(HttpStatusCode.Created);
         var createdResponse = await ApiClientResponse.GetResponses<HearingDetailsResponseV2>(result.Content);
+        Hooks.AddHearingForCleanup(createdResponse.Id);
         return createdResponse;
     }
     

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/CloneHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/CloneHearingTests.cs
@@ -1,0 +1,108 @@
+using BookingsApi.Client;
+using BookingsApi.Contract.V1.Requests;
+using BookingsApi.Contract.V2.Enums;
+using BookingsApi.Contract.V2.Requests;
+using BookingsApi.Contract.V2.Responses;
+using BookingsApi.DAL.Queries;
+using Testing.Common.Builders.Api.V2;
+
+namespace BookingsApi.IntegrationTests.Api.V2.Hearings;
+
+/// <summary>
+/// Although Clone hearing is a V1 endpoint, we need to test its ability to clone V2 hearings
+/// </summary>
+public class CloneHearingTests : ApiTest
+{
+    [Test]
+    public async Task should_clone_hearing_with_screening_requirements()
+    {
+        // arrange
+        using var client = Application.CreateClient();
+        var hearing = await BookHearingWithScreening(client);
+        var participantWithScreening = hearing.Participants.Find(x => x.Screening != null);
+        
+        var groupId = hearing.GroupId.GetValueOrDefault();
+
+        var dates = new List<DateTime> {hearing.ScheduledDateTime.AddDays(2), hearing.ScheduledDateTime.AddDays(3)};
+        
+        // act
+        var request = new CloneHearingRequest { Dates = dates }; // No duration specified - should use the default
+        var result = await client.PostAsync(ApiUriFactory.HearingsEndpoints.CloneHearing(hearing.Id), RequestBody.Set(request));
+        
+        // assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK, result.Content.ReadAsStringAsync().Result);
+        var bookingsApiClient = BookingsApiClient.GetClient(client);
+        
+        var groupedHearing = await bookingsApiClient.GetHearingsByGroupIdV2Async(groupId);
+        
+        groupedHearing.Count.Should().Be(dates.Count + 1);
+
+        // verify that the participant with screening is cloned correctly
+        foreach (var h in groupedHearing.Where(x=> x.Id != hearing.Id))
+        {
+            // get hearings by group does not include screening
+            await using var db = new BookingsDbContext(BookingsDbContextOptions);
+            var hearingFromQuery = await new GetHearingByIdQueryHandler(db).Handle(new GetHearingByIdQuery(h.Id));
+            // find by external reference id
+            var clonedParticipant = hearingFromQuery.Participants.First(x => x.ExternalReferenceId == participantWithScreening.ExternalReferenceId);
+            clonedParticipant.Should().NotBeNull();
+            
+            // verify that the screening is cloned correctly
+            clonedParticipant.Screening.Should().NotBeNull();
+            clonedParticipant.Screening.Type.Should().Be(Domain.Enumerations.ScreeningType.Specific);
+
+            var participantExternalRefs = clonedParticipant.Screening.GetParticipants().Select(x => x.Participant.ExternalReferenceId);
+            var endpointExternalRefs = clonedParticipant.Screening.GetEndpoints().Select(x => x.Endpoint.ExternalReferenceId);
+            var combinedExternalRefs = participantExternalRefs.Concat(endpointExternalRefs).ToList();
+            
+            combinedExternalRefs.Should().BeEquivalentTo(participantWithScreening.Screening.ProtectedFrom);
+        }
+        
+        
+        
+        groupedHearing.All(x => x.GroupId == groupId).Should().BeTrue();
+    }
+
+    private async Task<HearingDetailsResponseV2> BookHearingWithScreening(HttpClient client)
+    {
+        var request = await CreateBookingRequestWithServiceIdsAndCodes();
+        request.IsMultiDayHearing = true;
+        request.Participants = request.Participants.Take(2).ToList();
+        
+        var endpoint = new EndpointRequestV2
+        {
+            DisplayName = "Endpoint A",
+            ExternalParticipantId = Guid.NewGuid().ToString()
+        };
+        request.Endpoints.Add(endpoint);
+        
+        var participantWithSpecificScreening = request.Participants[0];
+        participantWithSpecificScreening.DisplayName = "Screen Specific Protected 1";
+        var protectedFrom = request.Participants[1];
+        
+        participantWithSpecificScreening.Screening = new ScreeningRequest
+        {
+            Type = ScreeningType.Specific,
+            ProtectedFrom = [protectedFrom.ExternalParticipantId, endpoint.ExternalParticipantId]
+        };
+        
+        var result = await client.PostAsync(ApiUriFactory.HearingsEndpointsV2.BookNewHearing, RequestBody.Set(request));
+        
+        result.IsSuccessStatusCode.Should().BeTrue();
+        result.StatusCode.Should().Be(HttpStatusCode.Created);
+        var createdResponse = await ApiClientResponse.GetResponses<HearingDetailsResponseV2>(result.Content);
+        return createdResponse;
+    }
+    
+    private async Task<BookNewHearingRequestV2> CreateBookingRequestWithServiceIdsAndCodes()
+    {
+        var personalCode = Guid.NewGuid().ToString();
+        await Hooks.AddJudiciaryPerson(personalCode);
+        var hearingSchedule = DateTime.UtcNow.AddMinutes(5);
+        var caseName = "Bookings Api Integration Automated";
+        var request = new SimpleBookNewHearingRequestV2(caseName, hearingSchedule, personalCode).Build();
+        request.ServiceId = "ZZY1"; // intentionally incorrect case
+        request.HearingVenueCode = "231596";
+        return request;
+    }
+}

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/GetConfirmedHearingsByUsernameForTodayTestsV2.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/GetConfirmedHearingsByUsernameForTodayTestsV2.cs
@@ -8,7 +8,7 @@ public class GetConfirmedHearingsByUsernameForTodayTestsV2 : ApiTest
     [Test]
     public async Task should_get_all_confirmed_hearings_for_today()
     {
-        var hearing1 = await Hooks.SeedVideoHearing(status: BookingStatus.Created,
+        var hearing1 = await Hooks.SeedVideoHearingV2(status: BookingStatus.Created,
                     configureOptions: options => { options.ScheduledDate = DateTime.UtcNow; });
         await Hooks.CloneVideoHearing(hearing1.Id, new List<DateTime> { DateTime.UtcNow }, BookingStatus.Created);
         await Hooks.CloneVideoHearing(hearing1.Id, new List<DateTime> { DateTime.UtcNow }, BookingStatus.Created);
@@ -27,7 +27,7 @@ public class GetConfirmedHearingsByUsernameForTodayTestsV2 : ApiTest
     [Test]
     public async Task should_return_notfound_when_no_confirmed_hearings_for_today()
     {
-        var hearing1 = await Hooks.SeedVideoHearing(status: BookingStatus.Created,
+        var hearing1 = await Hooks.SeedVideoHearingV2(status: BookingStatus.Created,
                     configureOptions: options => { options.ScheduledDate = DateTime.UtcNow.AddDays(1); });
         var username = hearing1.Participants[0].Person.Username;
 

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/GetHearingDetailsByIdV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/GetHearingDetailsByIdV2Tests.cs
@@ -98,6 +98,7 @@ public class GetHearingDetailsByIdV2Tests : ApiTest
         {
             hearingResponse.Endpoints.Should().ContainEquivalentOf(new EndpointResponseV2
             {
+                ExternalReferenceId = endpoint.ExternalReferenceId,
                 DisplayName = endpoint.DisplayName,
                 DefenceAdvocateId = endpoint.DefenceAdvocate?.Id,
                 Id = endpoint.Id,

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingV2Tests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V2/Hearings/UpdateHearingV2Tests.cs
@@ -81,7 +81,7 @@ public class UpdateHearingV2Tests : ApiTest
     public async Task should_return_bad_request_and_validation_failure_when_editing_a_created_hearing_close_to_start_time()
     {
         // arrange
-        var hearing = await Hooks.SeedVideoHearing(options => options.ScheduledDate = DateTime.UtcNow.AddMinutes(5), BookingStatus.Created);
+        var hearing = await Hooks.SeedVideoHearingV2(options => options.ScheduledDate = DateTime.UtcNow.AddMinutes(5), BookingStatus.Created);
         var hearingId = hearing.Id;
         var request = BuildRequest();
         
@@ -247,7 +247,7 @@ public class UpdateHearingV2Tests : ApiTest
     public async Task should_update_hearing_with_no_hearing_type_and_publish_when_hearing_status_is_created()
     {
         // arrange
-        var hearing = await Hooks.SeedVideoHearing(options =>
+        var hearing = await Hooks.SeedVideoHearingV2(options =>
         {
             options.Case = new Case("Case1 Num", "Case1 Name");
             options.ExcludeHearingType = true;
@@ -308,7 +308,7 @@ public class UpdateHearingV2Tests : ApiTest
     public async Task should_update_hearing_when_details_are_the_same()
     {
         // arrange
-        var hearing = await Hooks.SeedVideoHearing(options =>
+        var hearing = await Hooks.SeedVideoHearingV2(options =>
         {
             options.Case = new Case("Case1 Num", "Case1 Name");
         }, BookingStatus.Created);

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/AddParticipantsToVideoHearingCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/AddParticipantsToVideoHearingCommandTests.cs
@@ -55,6 +55,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var newPerson = new PersonBuilder(true).Build();
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson,
                 CaseRole = applicantCaseRole,
                 HearingRole = applicantRepresentativeHearingRole,
@@ -86,6 +88,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
 
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = representative.Person,
                 CaseRole = representative.CaseRole,
                 HearingRole = representative.HearingRole,
@@ -114,6 +118,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             representative.HearingRole.UserRole.Name = "NonExistent";
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = representative.Person,
                 CaseRole = representative.CaseRole,
                 HearingRole = representative.HearingRole,
@@ -181,6 +187,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var newPerson1 = new PersonBuilder(true).Build();
             var interpretee = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson,
                 CaseRole = applicantCaseRole,
                 HearingRole = applicantRepresentativeHearingRole,
@@ -189,6 +197,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             };
             var interpreter = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson1,
                 CaseRole = respondentCaseRole,
                 HearingRole = respondentRepresentativeHearingRole,
@@ -235,6 +245,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
 
             var interpreter = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson,
                 CaseRole = respondentCaseRole,
                 HearingRole = respondentRepresentativeHearingRole,
@@ -283,6 +295,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var newPerson = new PersonBuilder(true).Build();
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson,
                 CaseRole = judgeCaseRole,
                 HearingRole = judgeHearingRole,
@@ -324,6 +338,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var newPerson = new PersonBuilder(participantsFromHearing1[1].Person.Username, participantsFromHearing1[0].Person.ContactEmail).Build();
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson,
                 CaseRole = applicantCaseRole,
                 HearingRole = applicantRepresentativeHearingRole,
@@ -362,6 +378,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
 
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = existingPerson,
                 CaseRole = applicantCaseRole,
                 HearingRole = applicantRepresentativeHearingRole,

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/CreateVideoHearingCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/CreateVideoHearingCommandTests.cs
@@ -48,6 +48,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var newJudgePerson = new PersonBuilder(true).Build();
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson,
                 CaseRole = applicantCaseRole,
                 HearingRole = applicantRepresentativeHearingRole,

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateHearingParticipantsCommandHandlerTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateHearingParticipantsCommandHandlerTests.cs
@@ -76,6 +76,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var newPerson = new PersonBuilder(true).Build();
             var newParticipant = new NewParticipant()
             {
+                ExternalReferenceId = Guid.NewGuid().ToString(),
+                MeasuresExternalId = "Screening1",
                 Person = newPerson,
                 CaseRole = applicantCaseRole,
                 HearingRole = applicantRepresentativeHearingRole,

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateParticipantCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateParticipantCommandTests.cs
@@ -70,7 +70,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
                 Representee = representee
             };
             var requiredDto = new UpdateParticipantCommandRequiredDto(_newHearingId, representativeParticipant.Id, title, displayName, telephoneNumber, organisationName, null);
-            var optionalDto = new UpdateParticipantCommandOptionalDto(repInfo, null, null, null, null, null);
+            var optionalDto =
+                new UpdateParticipantCommandOptionalDto(repInfo, null, null, null, null, null, null, null);
             var updateParticipantCommand = new UpdateParticipantCommand(requiredDto, optionalDto);
             await _commandHandler.Handle(updateParticipantCommand);
 
@@ -173,7 +174,7 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             };
 
             var requiredDto = new UpdateParticipantCommandRequiredDto(_newHearingId, individualParticipant.Id, title, displayName, telephoneNumber, organisationName, null);
-            var optionalDto = new UpdateParticipantCommandOptionalDto(null, additionalInformation, null, null, null, null);
+            var optionalDto = new UpdateParticipantCommandOptionalDto(null, additionalInformation, null, null, null, null, null, null);
             var updateParticipantCommand = new UpdateParticipantCommand(requiredDto, optionalDto);
             await _commandHandler.Handle(updateParticipantCommand);
 
@@ -232,7 +233,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var contactEmail = "editedContactEmail@email.com";
 
             var requiredDto = new UpdateParticipantCommandRequiredDto(_newHearingId, individualParticipant.Id, title, displayName, telephoneNumber, organisationName, null);
-            var optionalDto = new UpdateParticipantCommandOptionalDto(null, additionalInformation, contactEmail, null, null, null);
+            var optionalDto = new UpdateParticipantCommandOptionalDto(null, additionalInformation, contactEmail, null,
+                null, null, null, null);
             var updateParticipantCommand = new UpdateParticipantCommand(requiredDto, optionalDto);
             await _commandHandler.Handle(updateParticipantCommand);
 
@@ -263,7 +265,9 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             };
 
             var requiredDto = new UpdateParticipantCommandRequiredDto(_newHearingId, individualParticipant.Id, title, displayName, telephoneNumber, organisationName, null);
-            var optionalDto = new UpdateParticipantCommandOptionalDto(null, additionalInformation, null, null, null, null);
+            var optionalDto =
+                new UpdateParticipantCommandOptionalDto(null, additionalInformation, null, null, null, null, null,
+                    null);
             var updateParticipantCommand = new UpdateParticipantCommand(requiredDto, optionalDto);
             await _commandHandler.Handle(updateParticipantCommand);
 
@@ -298,7 +302,8 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             var contactEmail = individualParticipant2.Person.ContactEmail;
 
             var requiredDto = new UpdateParticipantCommandRequiredDto(_newHearingId, individualParticipant.Id, title, displayName, telephoneNumber, organisationName, null);
-            var optionalDto = new UpdateParticipantCommandOptionalDto(null, additionalInformation, contactEmail, null, null, null);
+            var optionalDto = new UpdateParticipantCommandOptionalDto(null, additionalInformation, contactEmail, null,
+                null, null, null, null);
             var updateParticipantCommand = new UpdateParticipantCommand(requiredDto, optionalDto);
             await _commandHandler.Handle(updateParticipantCommand);
 

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetConfirmedHearingsByUsernameForTodayQueryHandlerTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetConfirmedHearingsByUsernameForTodayQueryHandlerTests.cs
@@ -34,7 +34,7 @@ namespace BookingsApi.IntegrationTests.Database.Queries
         [Test]
         public async Task Should_not_return_not_confirmed_hearings_for_username_for_today()
         {
-            var hearing1 = await Hooks.SeedVideoHearing(status: BookingStatus.Booked);
+            var hearing1 = await Hooks.SeedVideoHearingV2(status: BookingStatus.Booked);
             await Hooks.CloneVideoHearing(hearing1.Id, new List<System.DateTime> { System.DateTime.UtcNow });
 
             var username = hearing1.GetPersons()[0].Username;

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetHearingsByGroupIdQueryHandlerTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Queries/GetHearingsByGroupIdQueryHandlerTests.cs
@@ -35,7 +35,7 @@ namespace BookingsApi.IntegrationTests.Database.Queries
         [Test]
         public async Task Should_return_hearings_for_multi_day_by_groupId()
         {
-            var hearing1 = await Hooks.SeedVideoHearing(isMultiDayFirstHearing:true);
+            var hearing1 = await Hooks.SeedVideoHearingV2(isMultiDayFirstHearing:true);
             var groupId = hearing1.SourceId;
 
             var dates = new List<DateTime> {DateTime.Now.AddDays(2), DateTime.Now.AddDays(3)};

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/GetHearingsForNotificationTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/GetHearingsForNotificationTests.cs
@@ -141,7 +141,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
             }
 
             hearing.AddEndpoints(new List<Endpoint>
-                {new Endpoint("new endpoint", Guid.NewGuid().ToString(), "pin", null)});
+                {new Endpoint(Guid.NewGuid().ToString(), "new endpoint", Guid.NewGuid().ToString(), "pin", null)});
 
             return hearing;
         }

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/HearingsControllerTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/HearingsController/HearingsControllerTests.cs
@@ -576,7 +576,7 @@ namespace BookingsApi.UnitTests.Controllers.HearingsController
             }
 
             hearing.AddEndpoints(new List<Endpoint>
-                { new Endpoint("new endpoint", Guid.NewGuid().ToString(), "pin", null) });
+                { new Endpoint(Guid.NewGuid().ToString(), "new endpoint", Guid.NewGuid().ToString(), "pin", null) });
 
             return hearing;
         }

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/WorkAllocationsController/GetUnallocatedHearingsTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/WorkAllocationsController/GetUnallocatedHearingsTests.cs
@@ -96,7 +96,7 @@ namespace BookingsApi.UnitTests.Controllers.WorkAllocationsController
             }
 
             hearing.AddEndpoints(new List<Endpoint>
-                {new Endpoint("new endpoint", Guid.NewGuid().ToString(), "pin", null)});
+                {new Endpoint(Guid.NewGuid().ToString(), "new endpoint", Guid.NewGuid().ToString(), "pin", null)});
 
             return hearing;
         }
@@ -111,7 +111,7 @@ namespace BookingsApi.UnitTests.Controllers.WorkAllocationsController
             }
 
             hearing.AddEndpoints(new List<Endpoint>
-                { new Endpoint("new endpoint", Guid.NewGuid().ToString(), "pin", null) });
+                { new Endpoint(Guid.NewGuid().ToString(),"new endpoint", Guid.NewGuid().ToString(), "pin", null) });
 
             return hearing;
         }

--- a/BookingsApi/BookingsApi.UnitTests/Controllers/WorkAllocationsController/WorkAllocationsControllerTest.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Controllers/WorkAllocationsController/WorkAllocationsControllerTest.cs
@@ -38,7 +38,7 @@ namespace BookingsApi.UnitTests.Controllers.WorkAllocationsController
             }
 
             hearing.AddEndpoints(new List<Endpoint>
-                { new("new endpoint", Guid.NewGuid().ToString(), "pin", null) });
+                { new(Guid.NewGuid().ToString(),"new endpoint", Guid.NewGuid().ToString(), "pin", null) });
 
             return hearing;
         }

--- a/BookingsApi/BookingsApi.UnitTests/Domain/EndPoints/UpdateDisplayNameTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/EndPoints/UpdateDisplayNameTests.cs
@@ -9,7 +9,7 @@ namespace BookingsApi.UnitTests.Domain.EndPoints
         [SetUp]
         public void Initialise()
         {
-            _endpoint = new Endpoint("Original DisplayName", "sip@videohearings.net", "1234", null);
+            _endpoint = new Endpoint(Guid.NewGuid().ToString(),"Original DisplayName", "sip@videohearings.net", "1234", null);
         }
 
         [Test]

--- a/BookingsApi/BookingsApi.UnitTests/Domain/EndPoints/UpdateLanguagePreferencesTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/EndPoints/UpdateLanguagePreferencesTests.cs
@@ -11,7 +11,7 @@ public class UpdateLanguagePreferencesTests
     [SetUp]
     public void Setup()
     {
-        _endpoint = new Endpoint("Original DisplayName", "sip@videohearings.net", "1234", null);
+        _endpoint = new Endpoint(Guid.NewGuid().ToString(),"Original DisplayName", "sip@videohearings.net", "1234", null);
     }
         
     [Test]

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AddEndpointTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AddEndpointTests.cs
@@ -9,7 +9,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
         {
             var hearing = new VideoHearingBuilder().Build();
             var beforeAddCount = hearing.GetEndpoints().Count;
-            hearing.AddEndpoint(new BookingsApi.Domain.Endpoint("DisplayName", "sip@address.com", "1111", null));
+            hearing.AddEndpoint(new BookingsApi.Domain.Endpoint(Guid.NewGuid().ToString(),"DisplayName", "sip@address.com", "1111", null));
             var afterAddCount = hearing.GetEndpoints().Count;
             afterAddCount.Should().BeGreaterThan(beforeAddCount);
         }
@@ -18,7 +18,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
         public void should_not_add_existing_endpoint()
         {
             var hearing = new VideoHearingBuilder().Build();
-            var ep = new BookingsApi.Domain.Endpoint("DisplayName", "sip@address.com", "1111", null);
+            var ep = new BookingsApi.Domain.Endpoint(Guid.NewGuid().ToString(),"DisplayName", "sip@address.com", "1111", null);
             hearing.AddEndpoint(ep);
             var beforeAddCount = hearing.GetEndpoints().Count;
             Action action = () => hearing.AddEndpoint(ep);

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AssignDefenceAdvocateTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AssignDefenceAdvocateTests.cs
@@ -7,7 +7,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
         [Test]
         public void should_assign_defence_advocate()
         {
-            var ep = new Endpoint("DisplayName", "sip@address.com", "1111", null);
+            var ep = new Endpoint(Guid.NewGuid().ToString(),"DisplayName", "sip@address.com", "1111", null);
             var dA = new ParticipantBuilder().RepresentativeParticipantRespondent;
             
             ep.AssignDefenceAdvocate(dA);

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AssignScreeningForEndpointTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AssignScreeningForEndpointTests.cs
@@ -10,10 +10,10 @@ public class AssignScreeningForEndpointTests
     public void should_throw_exception_if_endpoint_participant_from_themself()
     {
         var hearing = new VideoHearingBuilder().Build();
-        var endpoint = new Endpoint("display name", "defence", "sip", null);
+        var endpoint = new Endpoint(Guid.NewGuid().ToString(), "display name", "defence", "sip", null);
         hearing.AddEndpoint(endpoint);
         
-        Action action = () => hearing.AssignScreeningForEndpoint(endpoint, ScreeningType.Specific, [], ["Display Name"]);
+        Action action = () => hearing.AssignScreeningForEndpoint(endpoint, ScreeningType.Specific, [endpoint.ExternalReferenceId]);
         action.Should().Throw<DomainRuleException>()
             .And.ValidationFailures.Should()
             .Contain(x => x.Message.Contains(DomainRuleErrorMessages.EndpointCannotScreenFromThemself));

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AssignScreeningForParticipantTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/AssignScreeningForParticipantTests.cs
@@ -12,34 +12,21 @@ public class AssignScreeningForParticipantTests
         var hearing = new VideoHearingBuilder().Build();
         var participant = hearing.Participants.First(x => x is Individual);
         
-        Action action = () => hearing.AssignScreeningForParticipant(participant, ScreeningType.Specific, [participant.Person.ContactEmail], []);
+        Action action = () => hearing.AssignScreeningForParticipant(participant, ScreeningType.Specific, [participant.ExternalReferenceId]);
         action.Should().Throw<DomainRuleException>()
             .And.ValidationFailures.Should()
             .Contain(x => x.Message.Contains(DomainRuleErrorMessages.ParticipantCannotScreenFromThemself));
     }
     
     [Test]
-    public void should_throw_exception_if_screening_from_participant_does_not_exist()
+    public void should_throw_exception_if_screening_from_entity_does_not_exist()
     {
         var hearing = new VideoHearingBuilder().Build();
         var participant = hearing.Participants.First(x => x is Individual);
         
-        Action action = () => hearing.AssignScreeningForParticipant(participant, ScreeningType.Specific, ["does-not-exist"], []);
+        Action action = () => hearing.AssignScreeningForParticipant(participant, ScreeningType.Specific, ["does-not-exist"]);
         action.Should().Throw<DomainRuleException>()
             .And.ValidationFailures.Should()
-            .Contain(x => x.Message.Contains(DomainRuleErrorMessages.ParticipantDoesNotExist));
-    }
-
-    [Test]
-    public void should_throw_exception_if_screen_from_endpoint_does_not_exist()
-    {
-        var hearing = new VideoHearingBuilder().Build();
-        var participant = hearing.Participants.First(x => x is Individual);
-        
-        Action action = () => hearing.AssignScreeningForParticipant(participant, ScreeningType.Specific, [], ["does-not-exist"]);
-        // should throw a DomainRuleException with the message contains DomainRuleErrorMessages.ParticipantDoesNotExist
-        action.Should().Throw<DomainRuleException>()
-            .And.ValidationFailures.Should()
-            .Contain(x => x.Message.Contains(DomainRuleErrorMessages.EndpointDoesNotExist));
+            .Contain(x => x.Message.Contains("The following external IDs were not found in the hearing"));
     }
 }

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RemoveEndpointsTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RemoveEndpointsTests.cs
@@ -11,9 +11,9 @@ namespace BookingsApi.UnitTests.Domain.Hearing
             var hearing = new VideoHearingBuilder().Build();
             hearing.AddEndpoints(new List<Endpoint>
             {
-                new Endpoint("new endpoint1", Guid.NewGuid().ToString(), "pin", null),
-                new Endpoint("new endpoint2", Guid.NewGuid().ToString(), "pin", null),
-                new Endpoint("new endpoint2", Guid.NewGuid().ToString(), "pin", null)
+                new Endpoint(Guid.NewGuid().ToString(),"new endpoint1", Guid.NewGuid().ToString(), "pin", null),
+                new Endpoint(Guid.NewGuid().ToString(),"new endpoint2", Guid.NewGuid().ToString(), "pin", null),
+                new Endpoint(Guid.NewGuid().ToString(),"new endpoint2", Guid.NewGuid().ToString(), "pin", null)
             });
             
             var beforeRemoveCount = hearing.GetEndpoints().Count;

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RemoveParticipantTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Hearing/RemoveParticipantTests.cs
@@ -12,7 +12,7 @@ namespace BookingsApi.UnitTests.Domain.Hearing
         {
             var hearing = new VideoHearingBuilder().Build();
             var beforeCount = hearing.GetParticipants().Count;
-            var participant = hearing.GetParticipants().First();
+            var participant = hearing.GetParticipants()[0];
 
             hearing.RemoveParticipant(participant);
             var afterCount =hearing.GetParticipants().Count;
@@ -24,15 +24,14 @@ namespace BookingsApi.UnitTests.Domain.Hearing
         {
             var hearing = new VideoHearingBuilder().Build();
             
-            var applicantCaseRole = new CaseRole(1, "Applicant");
             var applicantRepresentativeHearingRole = new HearingRole(2, "Representative");
             var newPerson = new PersonBuilder(true).Build();
             var participant = Builder<Representative>.CreateNew().WithFactory(() =>
-                new Representative(newPerson, applicantRepresentativeHearingRole, applicantCaseRole)
+                new Representative(Guid.NewGuid().ToString(), newPerson, applicantRepresentativeHearingRole, "Applicant1", "Representee1")
             ).Build();
             
             Action action = () => hearing.RemoveParticipant(participant);
-            action.Should().Throw<DomainRuleException>().And.ValidationFailures.Any(x =>
+            action.Should().Throw<DomainRuleException>().And.ValidationFailures.Exists(x =>
                 x.Name == "Participant" && x.Message == "Participant does not exist on the hearing").Should().BeTrue();
         }
     }

--- a/BookingsApi/BookingsApi.UnitTests/Domain/Screenings/RemoveEndpointTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Domain/Screenings/RemoveEndpointTests.cs
@@ -12,7 +12,7 @@ public class RemoveEndpointTests
     {
         var participant = new ParticipantBuilder().IndividualParticipantApplicant;
         var screening = new Screening(ScreeningType.Specific, participant);
-        var endpoint = new Endpoint("name", "sip", "pin", null);
+        var endpoint = new Endpoint(Guid.NewGuid().ToString(),"name", "sip", "pin", null);
         
         screening.UpdateScreeningList([], [endpoint]);
         screening.RemoveEndpoint(endpoint);
@@ -25,7 +25,7 @@ public class RemoveEndpointTests
     {
         var participant = new ParticipantBuilder().IndividualParticipantApplicant;
         var screening = new Screening(ScreeningType.Specific, participant);
-        var endpoint = new Endpoint("name", "sip", "pin", null);
+        var endpoint = new Endpoint(Guid.NewGuid().ToString(),"name", "sip", "pin", null);
         
         Action action = () => screening.RemoveEndpoint(endpoint);
         action.Should().Throw<DomainRuleException>()

--- a/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/IntegrationEventTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/IntegrationEventTests.cs
@@ -200,8 +200,10 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
         [Test]
         public void Should_publish_message_to_queue_when_EndpointAddedIntegrationEvent_is_raised()
         {
+            var hearing = new VideoHearingBuilder().Build();
+            hearing.AddEndpoint(new Endpoint(Guid.NewGuid().ToString(), "one", "sip", "1234", null));
             var endpointAddedIntegrationEvent =
-                new EndpointAddedIntegrationEvent(Guid.NewGuid(), new Endpoint(Guid.NewGuid().ToString(),"one", "sip", "1234", null));
+                new EndpointAddedIntegrationEvent(hearing, hearing.GetEndpoints().First());
             _eventPublisher.PublishAsync(endpointAddedIntegrationEvent);
 
             _serviceBusQueueClient.Count.Should().Be(1);
@@ -212,9 +214,11 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
         [Test]
         public void Should_publish_message_to_queue_when_EndpointAddedIntegrationEvent_is_raised_with_defence_advocate()
         {
-            var dA = new ParticipantBuilder().RepresentativeParticipantRespondent;
+            var hearing = new VideoHearingBuilder().Build();
+            var dA = hearing.GetParticipants().First(x => x is Representative);
+            hearing.AddEndpoint(new Endpoint(Guid.NewGuid().ToString(), "one", "sip", "1234", dA));
             var endpointAddedIntegrationEvent =
-                new EndpointAddedIntegrationEvent(Guid.NewGuid(), new Endpoint(Guid.NewGuid().ToString(),"one", "sip", "1234", dA));
+                new EndpointAddedIntegrationEvent(hearing, hearing.GetEndpoints().First());
             _eventPublisher.PublishAsync(endpointAddedIntegrationEvent);
 
             _serviceBusQueueClient.Count.Should().Be(1);
@@ -237,7 +241,7 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
         public void Should_publish_message_to_queue_when_EndpointUpdatedIntegrationEvent_is_raised()
         {
             var endpointUpdatedIntegrationEvent =
-                new EndpointUpdatedIntegrationEvent(Guid.NewGuid(), "sip", "name", "sol1@hmcts.net");
+                new EndpointUpdatedIntegrationEvent(Guid.NewGuid(), "sip", "name", "sol1@hmcts.net", "Host");
             _eventPublisher.PublishAsync(endpointUpdatedIntegrationEvent);
 
             _serviceBusQueueClient.Count.Should().Be(1);

--- a/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/IntegrationEventTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/IntegrationEventTests.cs
@@ -129,8 +129,8 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
             
             hearing.AddEndpoints(new List<Endpoint>
             {
-                new Endpoint("one", Guid.NewGuid().ToString(), "1234", null),
-                new Endpoint("two", Guid.NewGuid().ToString(), "1234", representative)
+                new Endpoint(Guid.NewGuid().ToString(),"one", Guid.NewGuid().ToString(), "1234", null),
+                new Endpoint(Guid.NewGuid().ToString(),"two", Guid.NewGuid().ToString(), "1234", representative)
             });
 
             var hearingIsReadyForVideoIntegrationEvent = new HearingIsReadyForVideoIntegrationEvent(hearing, hearing.Participants);
@@ -174,8 +174,8 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
             
             hearing.AddEndpoints(new List<Endpoint>
             {
-                new Endpoint("one", Guid.NewGuid().ToString(), "1234", null),
-                new Endpoint("two", Guid.NewGuid().ToString(), "1234", representative)
+                new Endpoint(Guid.NewGuid().ToString(),"one", Guid.NewGuid().ToString(), "1234", null),
+                new Endpoint(Guid.NewGuid().ToString(),"two", Guid.NewGuid().ToString(), "1234", representative)
             });
 
             var hearingIsReadyForVideoIntegrationEvent = new HearingIsReadyForVideoIntegrationEvent(hearing, hearing.Participants);
@@ -201,7 +201,7 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
         public void Should_publish_message_to_queue_when_EndpointAddedIntegrationEvent_is_raised()
         {
             var endpointAddedIntegrationEvent =
-                new EndpointAddedIntegrationEvent(Guid.NewGuid(), new Endpoint("one", "sip", "1234", null));
+                new EndpointAddedIntegrationEvent(Guid.NewGuid(), new Endpoint(Guid.NewGuid().ToString(),"one", "sip", "1234", null));
             _eventPublisher.PublishAsync(endpointAddedIntegrationEvent);
 
             _serviceBusQueueClient.Count.Should().Be(1);
@@ -214,7 +214,7 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
         {
             var dA = new ParticipantBuilder().RepresentativeParticipantRespondent;
             var endpointAddedIntegrationEvent =
-                new EndpointAddedIntegrationEvent(Guid.NewGuid(), new Endpoint("one", "sip", "1234", dA));
+                new EndpointAddedIntegrationEvent(Guid.NewGuid(), new Endpoint(Guid.NewGuid().ToString(),"one", "sip", "1234", dA));
             _eventPublisher.PublishAsync(endpointAddedIntegrationEvent);
 
             _serviceBusQueueClient.Count.Should().Be(1);

--- a/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/IntegrationEventTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Infrastructure.Services/IntegrationEventTests.cs
@@ -3,6 +3,7 @@ using BookingsApi.Domain;
 using BookingsApi.Domain.Enumerations;
 using BookingsApi.Domain.Participants;
 using BookingsApi.Domain.RefData;
+using BookingsApi.Infrastructure.Services.Dtos;
 using BookingsApi.Infrastructure.Services.IntegrationEvents;
 using BookingsApi.Infrastructure.Services.IntegrationEvents.Events;
 using BookingsApi.Infrastructure.Services.ServiceBusQueue;
@@ -241,7 +242,7 @@ namespace BookingsApi.UnitTests.Infrastructure.Services
         public void Should_publish_message_to_queue_when_EndpointUpdatedIntegrationEvent_is_raised()
         {
             var endpointUpdatedIntegrationEvent =
-                new EndpointUpdatedIntegrationEvent(Guid.NewGuid(), "sip", "name", "sol1@hmcts.net", "Host");
+                new EndpointUpdatedIntegrationEvent(Guid.NewGuid(), "sip", "name", "sol1@hmcts.net", ConferenceRole.Host);
             _eventPublisher.PublishAsync(endpointUpdatedIntegrationEvent);
 
             _serviceBusQueueClient.Count.Should().Be(1);

--- a/BookingsApi/BookingsApi.UnitTests/Mappings/V2/EndpointToResponseMapperTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Mappings/V2/EndpointToResponseMapperTests.cs
@@ -21,8 +21,7 @@ namespace BookingsApi.UnitTests.Mappings.V2
                 Screening = new ScreeningRequest()
                 {
                     Type = ScreeningType.Specific,
-                    ProtectFromParticipants = ["email1.com"],
-                    ProtectFromEndpoints = ["endpoint1"]
+                    ProtectedFrom = ["email1.com","endpoint1"]
                 }
             };
 
@@ -33,9 +32,7 @@ namespace BookingsApi.UnitTests.Mappings.V2
             result.DisplayName.Should().Be(endpointRequest.DisplayName);
             result.ContactEmail.Should().Be(endpointRequest.DefenceAdvocateContactEmail);
             result.Screening.ScreeningType.Should().Be(BookingsApi.Domain.Enumerations.ScreeningType.Specific);
-            result.Screening.ProtectFromParticipants.Should().BeEquivalentTo(endpointRequest.Screening.ProtectFromParticipants);
-            result.Screening.ProtectFromEndpoints.Should().BeEquivalentTo(endpointRequest.Screening.ProtectFromEndpoints);
-
+            result.Screening.ProtectedFrom.Should().BeEquivalentTo(endpointRequest.Screening.ProtectedFrom);
         }
 
         [Test]
@@ -43,13 +40,14 @@ namespace BookingsApi.UnitTests.Mappings.V2
         {
             var participant = new ParticipantBuilder().Build();
 
-            var source = new Endpoint("displayName", "sip", "pin", participant[0]);
+            var source = new Endpoint(Guid.NewGuid().ToString(), "displayName", "sip", "pin", participant[0]);
             var interpreterLanguage = new InterpreterLanguage(1, "spa", "Spanish", "WelshValue", InterpreterType.Verbal, true);
             source.UpdateLanguagePreferences(interpreterLanguage, null);
             
             var result = EndpointToResponseV2Mapper.MapEndpointToResponse(source);
 
             result.Id.Should().Be(source.Id);
+            result.ExternalReferenceId.Should().Be(source.ExternalReferenceId);
             result.DisplayName.Should().Be(source.DisplayName);
             result.Sip.Should().Be(source.Sip);
             result.Pin.Should().Be(source.Pin);
@@ -64,7 +62,7 @@ namespace BookingsApi.UnitTests.Mappings.V2
             // Arrange
             var participant = new ParticipantBuilder().Build();
 
-            var endpoint = new Endpoint("displayName", "sip", "pin", participant[0]);
+            var endpoint = new Endpoint(Guid.NewGuid().ToString(), "displayName", "sip", "pin", participant[0]);
             endpoint.UpdateLanguagePreferences(null, "OtherLanguage");
             
             // Act

--- a/BookingsApi/BookingsApi.UnitTests/Mappings/V2/ParticipantToResponseV2MapperTests.cs
+++ b/BookingsApi/BookingsApi.UnitTests/Mappings/V2/ParticipantToResponseV2MapperTests.cs
@@ -67,6 +67,7 @@ namespace BookingsApi.UnitTests.Mappings.V2
             HearingRole hearingRole)
         {
             response.Id.Should().Be(participant.Id);
+            response.ExternalReferenceId.Should().Be(participant.ExternalReferenceId);
             response.DisplayName.Should().Be(participant.DisplayName);
             response.HearingRoleName.Should().Be(hearingRole.Name);
             response.HearingRoleCode.Should().Be(hearingRole.Code);

--- a/BookingsApi/BookingsApi/Controllers/V1/HearingParticipantsController.cs
+++ b/BookingsApi/BookingsApi/Controllers/V1/HearingParticipantsController.cs
@@ -349,7 +349,8 @@ namespace BookingsApi.Controllers.V1
 
             var requiredDto = new UpdateParticipantCommandRequiredDto(hearingId, participantId, request.Title,
                 request.DisplayName, request.TelephoneNumber, request.OrganisationName, linkedParticipants);
-            var optionalDto = new UpdateParticipantCommandOptionalDto(representative, additionalInfo, request.ContactEmail, null, null, null);
+            var optionalDto = new UpdateParticipantCommandOptionalDto(representative, additionalInfo,
+                request.ContactEmail, null, null, null, null, null);
             var updateParticipantCommand = new UpdateParticipantCommand(
                 requiredDto, optionalDto);
             

--- a/BookingsApi/BookingsApi/Controllers/V2/HearingParticipantsControllerV2.cs
+++ b/BookingsApi/BookingsApi/Controllers/V2/HearingParticipantsControllerV2.cs
@@ -143,8 +143,13 @@ namespace BookingsApi.Controllers.V2
             request.ContactEmail = request.ContactEmail?.Trim();
 
             var screening = request.Screening?.MapToDalDto();
-            var requiredDto = new UpdateParticipantCommandRequiredDto(hearingId, participantId, request.Title, request.DisplayName, request.TelephoneNumber, request.OrganisationName, linkedParticipants);
-            var optionalDto = new UpdateParticipantCommandOptionalDto(representative, additionalInformation, request.ContactEmail, request.InterpreterLanguageCode, request.OtherLanguage, screening);
+            var requiredDto = new UpdateParticipantCommandRequiredDto(hearingId, participantId, request.Title,
+                request.DisplayName, request.TelephoneNumber, request.OrganisationName, linkedParticipants);
+            
+            var optionalDto = new UpdateParticipantCommandOptionalDto(representative, additionalInformation,
+                request.ContactEmail, request.InterpreterLanguageCode, request.OtherLanguage, screening,
+                request.ExternalParticipantId, participant.MeasuresExternalId);
+            
             var updateParticipantCommand = new UpdateParticipantCommand(requiredDto, optionalDto);
             var updatedParticipant = await hearingParticipantService.UpdateParticipantAndPublishEventAsync(videoHearing, updateParticipantCommand);
             

--- a/BookingsApi/BookingsApi/Mappings/V2/BookNewHearingRequestV2ToCreateVideoHearingCommandMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/BookNewHearingRequestV2ToCreateVideoHearingCommandMapper.cs
@@ -20,7 +20,7 @@ internal static class BookNewHearingRequestV2ToCreateVideoHearingCommandMapper
         var linkedParticipants = MapLinkedParticipants(requestV2);
         var judiciaryParticipants = MapJudiciaryParticipants(requestV2);
 
-        var conferenceSupplier = requestV2.BookingSupplier?.MapToDomainEnum() ?? VideoSupplier.Kinly;
+        var conferenceSupplier = requestV2.BookingSupplier?.MapToDomainEnum() ?? VideoSupplier.Vodafone;
         return new CreateVideoHearingCommand(
             new CreateVideoHearingRequiredDto(caseType, requestV2.ScheduledDateTime,
                 requestV2.ScheduledDuration, venue, cases, conferenceSupplier),

--- a/BookingsApi/BookingsApi/Mappings/V2/BookNewHearingRequestV2ToCreateVideoHearingCommandMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/BookNewHearingRequestV2ToCreateVideoHearingCommandMapper.cs
@@ -47,6 +47,8 @@ internal static class BookNewHearingRequestV2ToCreateVideoHearingCommandMapper
     {
         var dtos = requestV2.Endpoints.Select(x => new NewEndpointRequestDto()
         {
+            ExternalReferenceId = x.ExternalParticipantId,
+            MeasuresExternalId = x.MeasuresExternalId,
             DisplayName = x.DisplayName,
             DefenceAdvocateContactEmail = x.DefenceAdvocateContactEmail,
             OtherLanguage = x.OtherLanguage,

--- a/BookingsApi/BookingsApi/Mappings/V2/EndpointToResponseV2Mapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/EndpointToResponseV2Mapper.cs
@@ -25,6 +25,7 @@ namespace BookingsApi.Mappings.V2
             {
                 Id = endpoint.Id,
                 ExternalReferenceId = endpoint.ExternalReferenceId,
+                MeasuresExternalId = endpoint.MeasuresExternalId,
                 DisplayName = endpoint.DisplayName,
                 Sip = endpoint.Sip,
                 Pin = endpoint.Pin,

--- a/BookingsApi/BookingsApi/Mappings/V2/EndpointToResponseV2Mapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/EndpointToResponseV2Mapper.cs
@@ -24,6 +24,7 @@ namespace BookingsApi.Mappings.V2
             return new EndpointResponseV2
             {
                 Id = endpoint.Id,
+                ExternalReferenceId = endpoint.ExternalReferenceId,
                 DisplayName = endpoint.DisplayName,
                 Sip = endpoint.Sip,
                 Pin = endpoint.Pin,
@@ -56,6 +57,8 @@ namespace BookingsApi.Mappings.V2
                 ContactEmail = requestV2.DefenceAdvocateContactEmail,
                 OtherLanguage = requestV2.OtherLanguage,
                 LanguageCode = requestV2.InterpreterLanguageCode,
+                ExternalParticipantId = requestV2.ExternalParticipantId,
+                MeasuresExternalId = requestV2.MeasuresExternalId,
                 Screening = requestV2.Screening?.MapToDalDto()
             };
         }

--- a/BookingsApi/BookingsApi/Mappings/V2/Extensions/ScreeningRequestMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/Extensions/ScreeningRequestMapper.cs
@@ -8,9 +8,8 @@ public static class ScreeningRequestMapper
     {
         return new ScreeningDto
         {
-            ProtectFromEndpoints = request.ProtectFromEndpoints,
-            ProtectFromParticipants = request.ProtectFromParticipants,
-            ScreeningType = request.Type.MapToDomainEnum()
+            ScreeningType = request.Type.MapToDomainEnum(),
+            ProtectedFrom = request.ProtectedFrom
         };
     }
 }

--- a/BookingsApi/BookingsApi/Mappings/V2/ParticipantRequestV2ToNewParticipantMapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/ParticipantRequestV2ToNewParticipantMapper.cs
@@ -39,7 +39,9 @@ namespace BookingsApi.Mappings.V2
                 Representee = requestV2Participant.Representee,
                 OtherLanguage = requestV2Participant.OtherLanguage,
                 InterpreterLanguageCode = requestV2Participant.InterpreterLanguageCode,
-                Screening = requestV2Participant.Screening?.MapToDalDto()
+                Screening = requestV2Participant.Screening?.MapToDalDto(),
+                ExternalReferenceId = requestV2Participant.ExternalParticipantId,
+                MeasuresExternalId = requestV2Participant.MeasuresExternalId,
             };
         }
     }

--- a/BookingsApi/BookingsApi/Mappings/V2/ParticipantToResponseV2Mapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/ParticipantToResponseV2Mapper.cs
@@ -11,6 +11,7 @@ namespace BookingsApi.Mappings.V2
             var participantResponse = new ParticipantResponseV2
             {
                 Id = participant.Id,
+                ExternalReferenceId = participant.ExternalReferenceId,
                 DisplayName = participant.DisplayName,
                 HearingRoleCode = participant.HearingRole.Code,
                 HearingRoleName = participant.HearingRole.Name,

--- a/BookingsApi/BookingsApi/Mappings/V2/ParticipantToResponseV2Mapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/ParticipantToResponseV2Mapper.cs
@@ -12,6 +12,7 @@ namespace BookingsApi.Mappings.V2
             {
                 Id = participant.Id,
                 ExternalReferenceId = participant.ExternalReferenceId,
+                MeasuresExternalId = participant.MeasuresExternalId,
                 DisplayName = participant.DisplayName,
                 HearingRoleCode = participant.HearingRole.Code,
                 HearingRoleName = participant.HearingRole.Name,

--- a/BookingsApi/BookingsApi/Mappings/V2/ScreeningToResponseV2Mapper.cs
+++ b/BookingsApi/BookingsApi/Mappings/V2/ScreeningToResponseV2Mapper.cs
@@ -8,11 +8,13 @@ public static class ScreeningToResponseV2Mapper
 {
     public static ScreeningResponseV2 MapScreeningToResponse(Screening screening)
     {
+        var endpointIds = screening.GetEndpoints().Select(x => x.Endpoint.ExternalReferenceId).ToList();
+        var participantIds = screening.GetParticipants().Select(x => x.Participant.ExternalReferenceId).ToList();
+        
         return new ScreeningResponseV2
         {
             Type = screening.Type.MapToContractEnum(),
-            ProtectFromEndpointsIds = screening.GetEndpoints().Select(x=> x.EndpointId!.Value).ToList(),
-            ProtectFromParticipantsIds = screening.GetParticipants().Select(x=> x.ParticipantId!.Value).ToList()
+            ProtectedFrom = endpointIds.Concat(participantIds).ToList()
         };
     }
 }

--- a/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
+++ b/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
@@ -201,7 +201,9 @@ public class HearingParticipantService : IHearingParticipantService
                     CaseRole = updatedParticipant.CaseRole,
                     HearingRole = updatedParticipant.HearingRole,
                     DisplayName = updatedParticipant.DisplayName,
-                    Representee = representee
+                    Representee = representee,
+                    ExternalReferenceId = updatedParticipant.ExternalReferenceId,
+                    MeasuresExternalId = updatedParticipant.MeasuresExternalId,
                 }
             });
 
@@ -323,7 +325,9 @@ public class HearingParticipantService : IHearingParticipantService
             CaseRole = null,
             HearingRole = hearingRole,
             DisplayName = existingRequest.DisplayName,
-            Representee = existingRequest.Representee
+            Representee = existingRequest.Representee,
+            ExternalReferenceId = existingParticipant.ExternalReferenceId,
+            MeasuresExternalId = existingParticipant.MeasuresExternalId,
         };
     }
     

--- a/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
+++ b/BookingsApi/BookingsApi/Services/HearingParticipantService.cs
@@ -411,6 +411,8 @@ public class HearingParticipantService : IHearingParticipantService
         updatedDetails.OtherLanguage = existingParticipantRequestV2.OtherLanguage;
         
         updatedDetails.Screening = existingParticipantRequestV2.Screening?.MapToDalDto();
+        updatedDetails.MeasuresExternalId = existingParticipantRequestV2.MeasuresExternalId;
+        updatedDetails.ExternalReferenceId = existingParticipantRequestV2.ExternalParticipantId;
 
         return updatedDetails;
     }

--- a/BookingsApi/BookingsApi/Validations/V2/EndpointRequestValidationV2.cs
+++ b/BookingsApi/BookingsApi/Validations/V2/EndpointRequestValidationV2.cs
@@ -16,5 +16,10 @@ public class EndpointRequestValidationV2 : AbstractValidator<EndpointRequestV2>
         RuleFor(x => x.DisplayName).NotEmpty().Matches(regex).WithMessage(InvalidDisplayNameErrorMessage);
         RuleFor(x => x.DefenceAdvocateContactEmail).Must(x => x.IsValidEmail()).When(x => x.DefenceAdvocateContactEmail != null)
             .WithMessage(InvalidDefenceAdvocateContactEmailError);
+
+        When(x => x.Screening != null, () =>
+        {
+            RuleFor(x => x.Screening).SetValidator(new ScreeningRequestValidation());
+        });
     }
 }

--- a/BookingsApi/BookingsApi/Validations/V2/ParticipantRequestValidationV2.cs
+++ b/BookingsApi/BookingsApi/Validations/V2/ParticipantRequestValidationV2.cs
@@ -24,6 +24,11 @@ namespace BookingsApi.Validations.V2
                 .NotEmpty().WithMessage(NoDisplayNameErrorMessage)
                 .Matches(regex).WithMessage(InvalidDisplayNameErrorMessage);
             RuleFor(x => x.HearingRoleCode).NotEmpty().WithMessage(NoHearingRoleCodeErrorMessage);
+
+            When(x => x.Screening != null, () =>
+            {
+                RuleFor(x => x.Screening).SetValidator(new ScreeningRequestValidation());
+            });
         }
     }
 }

--- a/BookingsApi/BookingsApi/Validations/V2/ScreeningRequestValidation.cs
+++ b/BookingsApi/BookingsApi/Validations/V2/ScreeningRequestValidation.cs
@@ -1,0 +1,19 @@
+using System.Data;
+using BookingsApi.Contract.V2.Requests;
+using FluentValidation;
+using ScreeningType = BookingsApi.Contract.V2.Enums.ScreeningType;
+
+namespace BookingsApi.Validations.V2;
+
+public class ScreeningRequestValidation : AbstractValidator<ScreeningRequest>
+{
+    public ScreeningRequestValidation()
+    {
+        RuleFor(x => x.Type).IsInEnum();
+
+        RuleFor(x => x.ProtectedFrom).NotEmpty()
+            .ForEach(entry => entry.NotNull())
+            .When(x => x.Type == ScreeningType.Specific);
+
+    }
+}

--- a/BookingsApi/Testing.Common/Builders/Domain/ParticipantBuilder.cs
+++ b/BookingsApi/Testing.Common/Builders/Domain/ParticipantBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using BookingsApi.Domain.Participants;
 using BookingsApi.Domain.RefData;
 using System.Collections.Generic;
@@ -15,8 +16,6 @@ namespace Testing.Common.Builders.Domain
 
         public ParticipantBuilder(bool treatPersonAsNew = true)
         {
-            var applicantCaseRole = new CaseRole(1, "Applicant");
-            var respondentCaseRole = new CaseRole(2, "Respondent");
             var applicantLipHearingRole = new HearingRole(1, "Litigant in person")
             {
                 UserRole = new UserRole(5, "Individual")
@@ -33,13 +32,13 @@ namespace Testing.Common.Builders.Domain
             var person2 = new PersonBuilder(true, treatPersonAsNew:treatPersonAsNew).Build();
             var person3 = new PersonBuilder(true, treatPersonAsNew:treatPersonAsNew).Build();
 
-            _individualParticipant1 = new Individual(person1, applicantLipHearingRole, applicantCaseRole);
+            _individualParticipant1 = new Individual(Guid.NewGuid().ToString(), person1, applicantLipHearingRole, "Individual1");
             _individualParticipant1.HearingRole = applicantLipHearingRole;
             
-            _individualParticipant2 = new Individual(person2, respondentLipHearingRole, respondentCaseRole);
+            _individualParticipant2 = new Individual(Guid.NewGuid().ToString(), person2, respondentLipHearingRole, "Individual2");
             _individualParticipant2.HearingRole = respondentLipHearingRole;
             
-            _representativeParticipant = new Representative(person3, respondentRepresentativeHearingRole, respondentCaseRole);
+            _representativeParticipant = new Representative(Guid.NewGuid().ToString(), person3, respondentRepresentativeHearingRole, "Representative1", "Representee1");
             _representativeParticipant.HearingRole = respondentRepresentativeHearingRole;
             
             _participants.Add(_individualParticipant1);

--- a/BookingsApi/Testing.Common/Builders/Domain/VideoHearingBuilder.cs
+++ b/BookingsApi/Testing.Common/Builders/Domain/VideoHearingBuilder.cs
@@ -68,20 +68,17 @@ namespace Testing.Common.Builders.Domain
             _judgePerson = new PersonBuilder(true).Build();
             _johPerson = new PersonBuilder(true).Build();
 
-            _videoHearing.AddIndividual(person1, applicantLipHearingRole, applicantCaseRole,
-                $"{person1.FirstName} {person1.LastName}");
+            _videoHearing.AddIndividual(Guid.NewGuid().ToString(), person1, applicantLipHearingRole, $"{person1.FirstName} {person1.LastName}");
             var indApplicant = _videoHearing.Participants[^1];
             indApplicant.SetProtected(nameof(indApplicant.CaseRole), applicantCaseRole);
             indApplicant.SetProtected(nameof(indApplicant.HearingRole), applicantLipHearingRole);
 
-            _videoHearing!.AddIndividual(person3, respondentLipHearingRole, respondentCaseRole,
-                $"{person3.FirstName} {person3.LastName}");
+            _videoHearing!.AddIndividual(Guid.NewGuid().ToString(), person3, respondentLipHearingRole, $"{person3.FirstName} {person3.LastName}");
             var indRespondent = _videoHearing.Participants[^1];
             indRespondent.SetProtected(nameof(indApplicant.CaseRole), respondentCaseRole);
             indRespondent.SetProtected(nameof(indRespondent.HearingRole), respondentLipHearingRole);
 
-            _videoHearing!.AddRepresentative(person2, respondentRepresentativeHearingRole, respondentCaseRole,
-                $"{person2.FirstName} {person2.LastName}", string.Empty);
+            _videoHearing!.AddRepresentative(Guid.NewGuid().ToString(), person2, respondentRepresentativeHearingRole, $"{person2.FirstName} {person2.LastName}", string.Empty);
             var repRespondent = _videoHearing.Participants[^1];
             repRespondent.SetProtected(nameof(indApplicant.CaseRole), respondentCaseRole);
             repRespondent.SetProtected(nameof(repRespondent.HearingRole), respondentRepresentativeHearingRole);


### PR DESCRIPTION
### Jira link

VIH-11013

### Change description

Use external reference ids instead of contact emails and endpoint display names for screening

This pull request introduces several changes to the `BookingsApi` project, primarily focusing on adding external reference IDs to participants and endpoints, and updating the screening requirements. The most important changes include modifications to request and response classes, database schema updates, and adjustments to service methods.

### Request and Response Class Updates:

* Added `ExternalParticipantId` and `MeasuresExternalId` properties to Request and Response models for participants and endpoints
* [`BookingsApi/BookingsApi.Contract/V2/Requests/ScreeningRequest.cs`](diffhunk://#diff-714d319c1f9c3569ba6384d99f103c9f5b2199ae3e5fe026439b2451e9157c68L17-R19): Consolidated `ProtectFromParticipants` and `ProtectFromEndpoints` into a single `ProtectedFrom` list.
* [`BookingsApi/BookingsApi.Contract/V2/Responses/ScreeningResponseV2.cs`](diffhunk://#diff-1442a5cb13bfd2511fb5d6e2c63291b3dff9da7181b7d172a5255869db26c5a8L15-R16): Consolidated `ProtectFromParticipantsIds` and `ProtectFromEndpointsIds` into a single `ProtectedFrom` list.


### Database Schema Updates:

* [`AddExternalReferenceIdToParticipantAndEndpoint.cs`](diffhunk://#diff-1b4e85579f969b6b8ec39fd03ca76891ea6b22e70e25975d58a998b65501566cR1-R58): Created migration to add `ExternalReferenceId` and `MeasuresExternalId` columns to `Participant` and `Endpoint` tables.

### Service Method Adjustments:
* [`BookingsApi/BookingsApi.DAL/Commands/AddEndPointToHearingCommand.cs`](diffhunk://#diff-6001b70534c66a50530ba77ca2097a02785d36a66e43ea7b400be0ac8080d939L64-R66): Updated `Handle` method to use `ExternalParticipantId` when creating an `Endpoint`.
* [`BookingsApi/BookingsApi.DAL/Services/HearingService.cs`](diffhunk://#diff-e746e70fa2bfc872ee965715e4659d5cbec27bbc6cda4869857f5c3130fe0e04L94-R103): Updated methods to handle `ExternalReferenceId` and consolidate screening requirements into a single `ProtectedFrom` list. 

### Helper and DTO Updates:

* [`BookingsApi/BookingsApi.DAL/Dtos/NewParticipant.cs`](diffhunk://#diff-6e52cf58b680aab3d7ec2b48532d0e8abc2a32ab8d6442ea3a1a6aecdd52d91fR5-R19): Added `ExternalReferenceId` and `MeasuresExternalId` properties.
* [`BookingsApi/BookingsApi.DAL/Dtos/ScreeningDto.cs`](diffhunk://#diff-eb063acdd3954edf295307f51c49de10306c6d2f6d694b32731afc73eeb60f32L11-R13): Consolidated `ProtectFromParticipants` and `ProtectFromEndpoints` into a single `ProtectedFrom` list.
* [`BookingsApi/BookingsApi.DAL/Helper/CloneHearingToCommandMapper.cs`](diffhunk://#diff-7b8ff6ee9c07ce448ac17b8be1742eeafd170f5201260f270b34da517cc99603R30-R31): Updated `CloneToCommand` method to include `ExternalReferenceId` and `MeasuresExternalId`.


### Improvements to Screening Logic:

* [`BookingsApi/BookingsApi.Contract/V2/Requests/ScreeningRequest.cs`](diffhunk://#diff-714d319c1f9c3569ba6384d99f103c9f5b2199ae3e5fe026439b2451e9157c68L17-R19): Consolidated `ProtectFromParticipants` and `ProtectFromEndpoints` into a single `ProtectedFrom` list.
* [`BookingsApi/BookingsApi.Contract/V2/Responses/ScreeningResponseV2.cs`](diffhunk://#diff-1442a5cb13bfd2511fb5d6e2c63291b3dff9da7181b7d172a5255869db26c5a8L15-R16): Updated `ScreeningResponseV2` to use `ProtectedFrom` list instead of separate participant and endpoint IDs.
* [`BookingsApi/BookingsApi.DAL/Dtos/ScreeningDto.cs`](diffhunk://#diff-eb063acdd3954edf295307f51c49de10306c6d2f6d694b32731afc73eeb60f32L11-R13): Consolidated `ProtectFromParticipants` and `ProtectFromEndpoints` into a single `ProtectedFrom` list.
* [`BookingsApi/BookingsApi.DAL/Extensions/ScreeningExtensions.cs`](diffhunk://#diff-0014e2f30612e1401b3566c352a69791bc6bcf21520fa12dab7500732041b0bdR1-R24): Added a new extension method to map `Screening` to `ScreeningDto`.

### Updates to Command Handlers:

*  Updated command handler to include `ExternalParticipantId` and `MeasuresExternalId` properties and adjusted screening logic.

### Updates to DTOs:

* [`BookingsApi/BookingsApi.DAL/Dtos/ExistingParticipantDetails.cs`](diffhunk://#diff-9979404e0c988c6011bec6cd7c2af97b8413c4d9c6cfeceff3cc938de4676c6cR20-R21): Added `ExternalReferenceId` and `MeasuresExternalId` properties.
* [`BookingsApi/BookingsApi.DAL/Dtos/NewParticipant.cs`](diffhunk://#diff-6e52cf58b680aab3d7ec2b48532d0e8abc2a32ab8d6442ea3a1a6aecdd52d91fR6-R15): Added `ExternalReferenceId` and `MeasuresExternalId` properties.
* [`BookingsApi/BookingsApi.DAL/Dtos/UpdateParticipantDto.cs`](diffhunk://#diff-66ebf092b234e1d9225daeebde984371190b2296cfb640c0f223f39ac4f5b367L10-R10): Updated `UpdateParticipantCommandOptionalDto` to include `ExternalReferenceId` and `MeasuresExternalId`
* [`BookingsApi/BookingsApi.Infrastructure.Services/Dtos/HearingDto.cs`](diffhunk://#diff-66ebf092b234e1d9225daeebde984371190b2296cfb640c0f223f39ac4f5b367L10-R10): Updated `HearingDto` to include `ConferenceRoomType`
* [`BookingsApi/BookingsApi.Infrastructure.Services/Dtos/EndpointDto.cs`](diffhunk://#diff-66ebf092b234e1d9225daeebde984371190b2296cfb640c0f223f39ac4f5b367L10-R10): Updated `EndpointDto` to include `Role`