### PR TITLE
VIH-10843 add sonar to master build

### DIFF
--- a/azure-pipelines.sds.master-release.yml
+++ b/azure-pipelines.sds.master-release.yml
@@ -65,6 +65,35 @@ stages:
           gitVersionConfigPath: ${{ variables.git_version_config_path }}
 
 #####################################################
+# CI Build Tasks. ###################################
+- stage: CI_Build
+  dependsOn: []
+  variables:
+    - template: variables/shared.yaml
+  displayName: Test & Sonar
+  jobs:
+    - job: UnitAndIntegrationTests
+      displayName: 'Unit and Integration Tests'
+      steps:
+        - checkout: self
+
+        - template: templates/dotnet/build-test-analyse.yml@azTemplates
+          parameters:
+            dotnetVersion: ${{ variables.dotnetVersion }}
+            nugetConfigPath: nuget.config
+            appName: ${{ variables.appName }}
+            dockerComposeTestFile: docker-compose.tests.yml
+            sonarExtraProperties: |
+                sonar.cs.opencover.reportsPaths=$(System.DefaultWorkingDirectory)/coverage.opencover.xml
+                sonar.exclusions=**/Program.cs, **/Startup.cs, **/Testing.Common/**/*, **/BookingsApi/Swagger/**/*, **/BookingsApi.DAL/Migrations/*
+                sonar.coverage.exclusions=**/BookingsApi/Swagger/**/*, **/Program.cs, **/Startup.cs, **/Testing.Common/**/*, **/BookingsApi.Common/**/*, **/BookingsApi.IntegrationTests/**/*, **/BookingsApi.UnitTests/**/*, **/BookingsApi/Extensions/*, **/BookingsApi.DAL/Migrations/**/*
+                sonar.issue.ignore.multicriteria=e1,e2
+                sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.cs
+                sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S107
+                sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.cs
+                sonar.issue.ignore.multicriteria.e2.ruleKey=csharpsquid:S1133
+
+#####################################################
 # Manual Approval ###################################
 - ${{ each stage in parameters.stages }}:
   - stage: Manual_Approval_${{ stage.env }}


### PR DESCRIPTION
### Jira link

VIH-10843

### Change description

This pull request introduces a new CI build stage to the `azure-pipelines.sds.master-release.yml` file. The changes include setting up variables, defining the build and test jobs, and configuring SonarQube properties.

### CI Build Stage Addition:

* Added a new `CI_Build` stage with no dependencies and a display name "Test & Sonar". (`azure-pipelines.sds.master-release.yml`)