### PR TITLE
VIH-11275 Error removing JVS endpoint from hearing with screening

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Commands/RemoveEndPointFromHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/RemoveEndPointFromHearingCommand.cs
@@ -24,10 +24,20 @@
         public async Task Handle(RemoveEndPointFromHearingCommand command)
         {
             var hearing = await _context.VideoHearings
-                .Include(h => h.Participants).ThenInclude(x => x.Person)
-                .Include(x=> x.Participants).ThenInclude(x=> x.InterpreterLanguage)
-                .Include(h => h.Endpoints).ThenInclude(x => x.DefenceAdvocate)
-                .Include(x=> x.Endpoints).ThenInclude(x=> x.InterpreterLanguage)
+                .Include(h => h.Participants)
+                    .ThenInclude(p => p.Screening)
+                    .ThenInclude(s => s.ScreeningEntities)
+                .Include(h => h.Participants)
+                    .ThenInclude(x => x.Person)
+                .Include(x=> x.Participants)
+                    .ThenInclude(x=> x.InterpreterLanguage)
+                .Include(h => h.Endpoints)
+                    .ThenInclude(e => e.Screening)
+                    .ThenInclude(s => s.ScreeningEntities)
+                .Include(x => x.Endpoints)
+                    .ThenInclude(x => x.DefenceAdvocate)
+                .Include(x => x.Endpoints)
+                    .ThenInclude(x=> x.InterpreterLanguage)
                 .SingleOrDefaultAsync(x => x.Id == command.HearingId);
 
             if (hearing == null)

--- a/BookingsApi/BookingsApi.Domain/Hearing.cs
+++ b/BookingsApi/BookingsApi.Domain/Hearing.cs
@@ -418,6 +418,8 @@ namespace BookingsApi.Domain
                 .ToList()
                 .ForEach(existingEndpoint => existingEndpoint.Screening.RemoveEndpoint(endpoint));
 
+            endpoint.Screening?.ScreeningEntities.Clear();
+            
             Endpoints.Remove(endpoint);
             UpdatedDate = DateTime.UtcNow;
         }

--- a/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Endpoints/RemoveEndPointFromHearingTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Api/V1/Endpoints/RemoveEndPointFromHearingTests.cs
@@ -32,12 +32,13 @@ public class RemoveEndPointFromHearingTests : ApiTest
     }
     
     [Test]
-    public async Task should_remove_endpoint_from_and_publish_message_when_hearing_is_created_and_found()
+    public async Task should_remove_endpoint_that_has_screenings_from_and_publish_message_when_hearing_is_created_and_found()
     {
         // arrange
         var seededHearing = await Hooks.SeedVideoHearingV2(options =>
         {
             options.EndpointsToAdd = 3;
+            options.AddScreening = true;
         }, BookingStatus.Created);
         using var client = Application.CreateClient();
         var endpoint = seededHearing.GetEndpoints()[0];


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11275

missing includes from remove endpoint command, means screening entity composite table was not being cleared down when endpoint is removed, causing fk contraint on context update