### PR TITLE
VIH-11404 Refactor endpoint update logic to set UpdatedEndpoint earlier and add test for role publishing on screening addition

### DIFF
--- a/BookingsApi/BookingsApi.DAL/Commands/UpdateEndPointOfHearingCommand.cs
+++ b/BookingsApi/BookingsApi.DAL/Commands/UpdateEndPointOfHearingCommand.cs
@@ -74,11 +74,9 @@ public class UpdateEndPointOfHearingCommandHandler(BookingsDbContext context, IH
         endpoint.UpdateExternalIds(command.ExternalReferenceId, command.MeasuresExternalId);
 
         var endpointHasChanged = endpoint.UpdatedDate != originalUpdatedDate;
-        if (!endpointHasChanged) return;
-            
-        await context.SaveChangesAsync();
-
         command.UpdatedEndpoint = endpoint;
+        if (!endpointHasChanged) return;
+        await context.SaveChangesAsync();
     }
 
     private static void UpdateEndpointParticipants(UpdateEndPointOfHearingCommand command, Endpoint endpoint, VideoHearing hearing)

--- a/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateEndPointOfHearingCommandTests.cs
+++ b/BookingsApi/BookingsApi.IntegrationTests/Database/Commands/UpdateEndPointOfHearingCommandTests.cs
@@ -175,7 +175,6 @@ namespace BookingsApi.IntegrationTests.Database.Commands
             // Assert
             var updatedEndpoint = await _getHearingByIdQueryHandler.Handle(new GetHearingByIdQuery(seededHearing.Id));
             updatedEndpoint.UpdatedDate.Should().BeCloseTo(originalUpdatedDate, TimeSpan.FromMilliseconds(50)); // The two dates should be the same, but there is a small discrepancy with EF
-            command.UpdatedEndpoint.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
### Jira link

VIH-11404

### Change description

Since the conference role is detected after the EF update, and the publishing is only executed if the entity itself has changed then the conference role update will be missed if the entity itself has not been updated directly in any way